### PR TITLE
Remove outdated numeric string-conversion note

### DIFF
--- a/docs/ECMAViolations.txt
+++ b/docs/ECMAViolations.txt
@@ -3,9 +3,6 @@ Violations
 
 *) \0 is interpreted as null char even if followed by decimals (octals are not supported)
 
-*) Number -> string conversion doesn't fully follow the ECMAScript rules. Uses slightly lower precision (and prefers E
-notation a bit more often) to avoid rouding errors.
-
 *) Doesn't consider unicode Line separator <LS> (\u2028) or Paragraph separator <PS> (\u2029) to be linefeeds. Only LF
 	or CR. Also <NBSP> (\u00A0) and <ZWNBSP> ZERO WIDTH NO-BREAK SPACE (\uFEFF) are not considered white space. FIX :
 	yes it does now, except \uFEFF

--- a/tests/stdlib/numberRoundTrip.io
+++ b/tests/stdlib/numberRoundTrip.io
@@ -1,0 +1,28 @@
+> function ulp(x) {
+>     var a = Math.abs(x);
+>     if (a === 0) return Math.pow(2, -1074);
+>     var e = Math.floor(Math.log(a) / Math.LN2);
+>     if (e <= -1022) return Math.pow(2, -1074);
+>     return Math.pow(2, e - 52);
+> }
+> function rt(x) { return Number(x.toString()) === x; }
+> var exps = [ -1020, -500, -200, -100, -50, -20, -10, -1, 0, 1, 10, 20, 50, 100, 200, 500, 1020 ];
+> var mult = [ 1, -1, 1.2345, -1.2345, 3.141592653589793, -3.141592653589793, 0.1, -0.1 ];
+> var vals = [ 0, -0, Math.pow(2, -1074), -Math.pow(2, -1074) ];
+> for (var i = 0; i < exps.length; ++i) {
+>     var f = Math.pow(2, exps[i]);
+>     for (var j = 0; j < mult.length; ++j) {
+>         var v = f * mult[j];
+>         if (isFinite(v)) vals[vals.length] = v;
+>     }
+> }
+> var ok = true;
+> for (var i = 0; i < vals.length && ok; ++i) {
+>     var v = vals[i];
+>     if (!rt(v)) ok = false;
+>     var u = ulp(v);
+>     if (isFinite(v + u) && !rt(v + u)) ok = false;
+>     if (isFinite(v - u) && !rt(v - u)) ok = false;
+> }
+> print(ok ? 'roundtrip-ok' : 'roundtrip-fail');
+< roundtrip-ok


### PR DESCRIPTION
## Summary
- drop the obsolete line in `ECMAViolations.txt` about `Number` string conversion

## Testing
- `timeout 120 ./tools/buildAndTest.sh`

------
https://chatgpt.com/codex/tasks/task_e_6867b259074c833294c555e214dd23d2