### PR TITLE
Fix async example to avoid race condition

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -15,7 +15,8 @@ The available examples are:
 - **callback_example.cpp** – JavaScript calling back into C++.
 - **object_creation_example.cpp** – Building objects and arrays from C++.
 - **time_memory_limits_example.cpp** – Enforcing memory and execution time caps.
-- **asynchronous_example.cpp** – Using a `Processor` to run in small time slices.
+- **asynchronous_example.cpp** – Running two processors in parallel while each
+  keeps its own partial sum to avoid race conditions.
 - **property_enumeration_example.cpp** – Iterating properties including the prototype chain.
 - **error_handling_example.cpp** – Translating exceptions between languages.
 - **custom_object_example.cpp** – Defining a native `Counter` object.

--- a/examples/expected_asynchronous_example.txt
+++ b/examples/expected_asynchronous_example.txt
@@ -19,4 +19,5 @@ tick
 tick
 tick
 tick
-result=35
+tick
+result=45


### PR DESCRIPTION
## Summary
- update asynchronous example to avoid data races by storing partial sums separately
- update expected output
- clarify description in examples README

## Testing
- `timeout 120 ./tools/buildAndTest.sh`

------
https://chatgpt.com/codex/tasks/task_e_686a7283f84c8332b99f654a280470a2