### PR TITLE
Improve REPL exception handling

### DIFF
--- a/TODO_LIST.txt
+++ b/TODO_LIST.txt
@@ -5,19 +5,6 @@ tools/initPPEG.pika:47:	swap(@::ppeg.$compileTo, @target);	// FIX : ugly non-ree
 tools/NuXJSREPL.cpp:268:		if (f == 0) { // FIX : sub to make is not a function error or something?
     			ScriptException::throwError(heap, TYPE_ERROR, String::concatenate(heap, *argv[0].toString(heap), String(" is not a function")));
     		}
-
-tools/NuXJSREPL.cpp:430:	// FIX : exception handling on top-level
-        String source(EMPTY_STRING);
-        std::string inputFilePath;
-
-tools/NuXJSREPL.cpp:435:    int gcRate = 256; // FIX : drop or what?
-        size_t peakMemory = 0;
-        bool autoGCRate = true;
-
-tools/NuXJSREPL.cpp:532:                // FIX : add #undo that drops just the last one
-                    if (utf8Line == "#save" || utf8Line.compare(0, 6, "#save ") == 0) {
-                        std::wstring s;
-
 tools/NuXJSREPL.cpp:569:                        source = String(heap.roots(), String(heap.roots(), String("print("), String(heap.roots(), source.begin() + 1, source.end())), String(")")); // FIX : operator +
                         }
                         if (interactive) {

--- a/tools/NuXJSREPL.cpp
+++ b/tools/NuXJSREPL.cpp
@@ -427,23 +427,17 @@ void randomSeed() {
 }
 
 int testMain(int argc, const char* argv[]) {
-	// FIX : exception handling on top-level
+    try {
     String source(EMPTY_STRING);
     std::string inputFilePath;
     std::istream* inStream = &std::cin;
     bool doTime = false;
-    int gcRate = 256; // FIX : drop or what?
     size_t peakMemory = 0;
-    bool autoGCRate = true;
     bool doSuppressStdErr = false;
     bool loadStdLib = true;
     for (int argi = 1; argi < argc; ++argi) {
         if (strcmp(argv[argi], "-t") == 0) doTime = true;
         else if (strcmp(argv[argi], "-s") == 0) doSuppressStdErr = true;
-        else if (argi + 1 < argc && strcmp(argv[argi], "-gc") == 0) {
-            gcRate = atoi(argv[++argi]);
-            autoGCRate = false;
-        }
         else if (strcmp(argv[argi], "-p") == 0) pauseBeforeQuit = true;
         else if (strcmp(argv[argi], "-n") == 0) loadStdLib = false;
         else if (inputFilePath.empty()) {
@@ -674,6 +668,17 @@ int testMain(int argc, const char* argv[]) {
         return 1;
     }
     return 0;
+    }
+    catch (const Exception& x) {
+        std::cerr << "Uncaught exception: " << x.what() << std::endl;
+    }
+    catch (const std::exception& x) {
+        std::cerr << "Uncaught std::exception: " << x.what() << std::endl;
+    }
+    catch (...) {
+        std::cerr << "Uncaught unknown exception" << std::endl;
+    }
+    return 1;
 }
 
 #ifdef LIBFUZZ


### PR DESCRIPTION
## Summary
- wrap `testMain` in `NuXJSREPL.cpp` with a top-level try/catch
- remove unused `gcRate` and `autoGCRate` argument handling
- trim TODO list

## Testing
- `timeout 120 ./tools/buildAndTest.sh`

------
https://chatgpt.com/codex/tasks/task_e_686aa806bacc833280b4ae5f8dac2eb6