### PR TITLE
Add formatting guidelines and clang-format config

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,10 @@
+BasedOnStyle: LLVM
+UseTab: ForIndentation
+IndentWidth: 4
+TabWidth: 4
+ColumnLimit: 120
+BreakBeforeBraces: Attach
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Empty
+IndentCaseLabels: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,5 +10,15 @@ Always execute this command before committing changes to verify that the build a
 
 Please use tabs (not spaces) for indentation throughout.
 
+### Formatting rules
+Source files are formatted with `clang-format` using the configuration in `.clang-format`.
+Run `clang-format -i <file>` or `clang-format -n --Werror <file>` before committing.
+Key style points:
+- Tabs (width 4) for indentation.
+- Opening braces stay on the same line as the control statement and closing braces are on their own line.
+- Maximum line width is 120 characters. End-of-line comments may start at column 120.
+- Line continuations should start with the operator and be indented two tabs from the original line.
+- `#if`/`#endif` blocks should appear one tab *left* of the current indentation level.
+
 See `docs/NuXJS Documentation.md` for details on how `src/stdlib.js` is
 minified and converted to `src/stdlibJS.cpp` during the build.


### PR DESCRIPTION
## Summary
- document detailed formatting rules and clang-format usage
- add project `.clang-format` configuration

## Testing
- `timeout 120 ./tools/buildAndTest.sh`

------
https://chatgpt.com/codex/tasks/task_e_686bb4ccdbdc8332be74e5c6750d46eb