### PR TITLE
Add PikaCmd note to AGENTS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,10 @@ timeout 120 ./tools/buildAndTest.sh
 
 Always execute this command before committing changes to verify that the build and regression tests succeed.
 
+### PikaCmd directory
+The `tools/PikaCmd` folder is a separate project copied into this repository.
+Ignore it when applying formatting or running tests.
+
 Please use tabs (not spaces) for indentation throughout.
 
 ### Formatting rules


### PR DESCRIPTION
## Summary
- add a note clarifying that `tools/PikaCmd` is a separate project and should be ignored when running tests or formatting

## Testing
- `timeout 120 ./tools/buildAndTest.sh`

------
https://chatgpt.com/codex/tasks/task_e_686bb83f7fd48332b092b2a6c366bb67