### PR TITLE
Add root build helpers

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,0 +1,32 @@
+@ECHO OFF
+
+SETLOCAL ENABLEEXTENSIONS ENABLEDELAYEDEXPANSION
+
+
+
+SET target=%1
+
+SET model=%2
+
+IF "%target%"=="" SET target=release
+
+IF "%model%"=="" SET model=native
+
+
+
+CALL tools\buildAndTest.cmd %target% %model% || GOTO error
+
+IF EXIST output\NuXJScript_%target%_%model%.exe (
+
+	MOVE /Y output\NuXJScript_%target%_%model%.exe output\NuXJScript.exe >NUL
+
+)
+
+EXIT /b 0
+
+
+
+:error
+
+EXIT /b %ERRORLEVEL%
+

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e -o pipefail
+cd "$(dirname "$0")"
+
+target=${1:-release}
+model=${2:-native}
+
+./tools/buildAndTest.sh "$target" "$model"
+
+if [ -f "output/NuXJScript_${target}_${model}" ]; then
+	mv -f "output/NuXJScript_${target}_${model}" "output/NuXJScript"
+fi


### PR DESCRIPTION
## Summary
- introduce `build.sh` and `build.cmd` wrappers that call `tools/buildAndTest`
- rename the release build to `NuXJScript`

## Testing
- `timeout 120 ./tools/buildAndTest.sh`

------
https://chatgpt.com/codex/tasks/task_e_6871073b86748332ba33bbccdb2864c4