### PR TITLE
Update helper scripts and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,12 +65,17 @@ int main(int argc, const char* argv[]) {
 
 ## Helper Scripts
 
-- `tools/buildGAZLCmd.sh / .bat` – builds the GAZL virtual machine
-- `tools/BuildImpala.sh / .bat` – builds the Impala compiler and packages the output
+- `build.sh` / `build.cmd` – build both the **beta** and **release** targets and run all tests
+- `tools/buildAndTest.sh` / `.cmd` – build and test a single configuration
+- `tools/runExamples.sh` / `.cmd` – compile and run all example programs
+- `tools/testAllConfigs.sh` / `.cmd` – exercise every debug and release build for each CPU model
+- `tools/BuildCpp.sh` / `.cmd` – low-level wrapper around the C++ compiler
 
-## Documentation
+ ## Documentation
 
-- `docs/NuXJS Documentation.md`
+ - [NuXJS Documentation](docs/NuXJS%20Documentation.md)
+ - [Changes for ES5](docs/ChangesForES5.txt)
+ - [Native Call Thoughts](docs/NativeCallThoughts.txt)
 
 ## AI Usage
 

--- a/tools/buildAndTest.cmd
+++ b/tools/buildAndTest.cmd
@@ -20,6 +20,7 @@ CALL .\BuildCpp.cmd %target% %model% ..\output\NuXJSTest_%target%_%model%.exe .\
 ..\output\NuXJSTest_%target%_%model% || GOTO error
 CALL .\BuildCpp.cmd %target% %model% ..\output\NuXJScript_%target%_%model%.exe .\NuXJSREPL.cpp ..\src\NuXJScript.cpp ..\src\stdlibJS.cpp || GOTO error
 .\PikaCmd\PikaCmd.exe .\test.pika -e -x ..\output\NuXJScript_%target%_%model% ..\tests\ || GOTO error
+CALL runExamples.cmd || GOTO error
 ECHO Success!
 POPD
 EXIT /b 0

--- a/tools/buildAndTest.sh
+++ b/tools/buildAndTest.sh
@@ -22,5 +22,6 @@ mkdir ../output >/dev/null 2>&1 || true
 ../output/NuXJSTest_${target}_${model}
 ./BuildCpp.sh $target $model ../output/NuXJScript_${target}_${model} ../tools/NuXJSREPL.cpp ../src/NuXJScript.cpp ../src/stdlibJS.cpp
 ./PikaCmd/PikaCmd ./test.pika -e -x ../output/NuXJScript_${target}_${model} ../tests/
+./runExamples.sh
 
 echo Success!

--- a/tools/testAllConfigs.cmd
+++ b/tools/testAllConfigs.cmd
@@ -3,18 +3,37 @@ SETLOCAL ENABLEEXTENSIONS ENABLEDELAYEDEXPANSION
 
 PUSHD %~dp0
 
-CALL buildAndTest.cmd debug x86 || GOTO :error
-CALL buildAndTest.cmd debug x64 || GOTO :error
-CALL buildAndTest.cmd debug arm64 || GOTO :error
-CALL buildAndTest.cmd release x86 || GOTO :error
-CALL buildAndTest.cmd release x64 || GOTO :error
-CALL buildAndTest.cmd release arm64 || GOTO :error
+SET tmp=%TEMP%\nuxjs_test%RANDOM%.cpp
+ECHO int main() { return 0; } > "%tmp%"
 
+SET fail=0
+
+CALL :testModel x86
+CALL :testModel x64
+CALL :testModel arm64
+
+DEL "%tmp%" >NUL 2>&1
+
+IF %fail% EQU 0 (
 ECHO Success!
 POPD
 EXIT /B 0
+) ELSE (
+GOTO error
+)
 
 :error
 ECHO Error %ERRORLEVEL%
 POPD
 EXIT /B %ERRORLEVEL%
+
+:testModel
+CALL BuildCpp.cmd debug %1 %TEMP%\nuxjs_model.exe "%tmp%" >NUL 2>&1
+IF ERRORLEVEL 1 (
+ECHO Skipping %1 - compiler not available
+EXIT /B 0
+)
+DEL %TEMP%\nuxjs_model.exe >NUL 2>&1
+CALL buildAndTest.cmd debug %1 || SET fail=1
+CALL buildAndTest.cmd release %1 || SET fail=1
+EXIT /B 0

--- a/tools/testAllConfigs.sh
+++ b/tools/testAllConfigs.sh
@@ -3,12 +3,22 @@
 set -e -o pipefail -u
 cd "${0%/*}"
 
-# export CPP_COMPILER=g++
-./buildAndTest.sh debug x86
-./buildAndTest.sh debug x64
-./buildAndTest.sh debug arm64
-./buildAndTest.sh release x86
-./buildAndTest.sh release x64
-./buildAndTest.sh release arm64
+tmp=$(mktemp /tmp/test.cppXXXX)
+echo 'int main() { return 0; }' >"$tmp"
 
+test_model() {
+if ./BuildCpp.sh debug "$1" ../output/tmp_"$1" "$tmp" >/dev/null 2>&1; then
+rm -f ../output/tmp_"$1"
+./buildAndTest.sh debug "$1"
+./buildAndTest.sh release "$1"
+else
+echo "Skipping $1 - compiler not available"
+fi
+}
+
+test_model x86
+test_model x64
+test_model arm64
+
+rm -f "$tmp"
 echo Success!


### PR DESCRIPTION
## Summary
- update helper script list in README
- link to more documentation files
- run example programs as part of buildAndTest
- skip unavailable configs in testAllConfigs

## Testing
- `timeout 120 ./tools/buildAndTest.sh`

------
https://chatgpt.com/codex/tasks/task_e_6872320bd3bc83328ee1d903fe33e8fe