### PR TITLE
Fix RTTI for examples

### DIFF
--- a/tools/buildAndTest.cmd
+++ b/tools/buildAndTest.cmd
@@ -20,7 +20,7 @@ CALL .\BuildCpp.cmd %target% %model% ..\output\NuXJSTest_%target%_%model%.exe .\
 ..\output\NuXJSTest_%target%_%model% || GOTO error
 CALL .\BuildCpp.cmd %target% %model% ..\output\NuXJScript_%target%_%model%.exe .\NuXJSREPL.cpp ..\src\NuXJScript.cpp ..\src\stdlibJS.cpp || GOTO error
 .\PikaCmd\PikaCmd.exe .\test.pika -e -x ..\output\NuXJScript_%target%_%model% ..\tests\ || GOTO error
-CALL runExamples.cmd || GOTO error
+CALL runExamples.cmd %target% || GOTO error
 ECHO Success!
 POPD
 EXIT /b 0

--- a/tools/buildAndTest.sh
+++ b/tools/buildAndTest.sh
@@ -22,6 +22,6 @@ mkdir ../output >/dev/null 2>&1 || true
 ../output/NuXJSTest_${target}_${model}
 ./BuildCpp.sh $target $model ../output/NuXJScript_${target}_${model} ../tools/NuXJSREPL.cpp ../src/NuXJScript.cpp ../src/stdlibJS.cpp
 ./PikaCmd/PikaCmd ./test.pika -e -x ../output/NuXJScript_${target}_${model} ../tests/
-./runExamples.sh
+./runExamples.sh "$target"
 
 echo Success!

--- a/tools/runExamples.cmd
+++ b/tools/runExamples.cmd
@@ -2,11 +2,13 @@
 SETLOCAL ENABLEEXTENSIONS ENABLEDELAYEDEXPANSION
 PUSHD %~dp0\..
 IF NOT EXIST output mkdir output
+SET target=%~1
+IF "%target%"=="" SET target=debug
 SET fail=0
 FOR %%F IN (examples\*.cpp) DO (
     SET name=%%~nF
     ECHO Building %%F
-    CALL tools\BuildCpp.cmd debug output\!name! %%F src\NuXJScript.cpp src\stdlibJS.cpp || SET fail=1
+    CALL tools\BuildCpp.cmd %target% output\!name! %%F src\NuXJScript.cpp src\stdlibJS.cpp || SET fail=1
     IF !fail! EQU 0 (
         ECHO Running !name!
         output\!name!.exe > output\!name!.log 2>&1

--- a/tools/runExamples.sh
+++ b/tools/runExamples.sh
@@ -3,12 +3,13 @@ set -e -u -o pipefail
 cd "${0%/*}/.."
 
 mkdir -p output
+target=${1:-debug}
 fail=0
 for src in examples/*.cpp; do
     name=$(basename "$src" .cpp)
     exe="./output/$name"
     echo "Building $name"
-    ./tools/BuildCpp.sh debug "$exe" "$src" src/NuXJScript.cpp src/stdlibJS.cpp || fail=1
+    ./tools/BuildCpp.sh "$target" "$exe" "$src" src/NuXJScript.cpp src/stdlibJS.cpp || fail=1
     if [ $fail -eq 0 ]; then
         echo "Running $name"
         if "$exe" > "output/${name}.log" 2>&1; then


### PR DESCRIPTION
## Summary
- allow runExamples scripts to build with the same target as the library
- pass the selected target from buildAndTest

## Testing
- `timeout 120 ./tools/buildAndTest.sh release x64`

------
https://chatgpt.com/codex/tasks/task_e_6872584b222c8332b1dab23d2d228613