### PR TITLE
Fix root build scripts for portable invocation

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,5 +1,6 @@
 @ECHO OFF
 SETLOCAL ENABLEEXTENSIONS ENABLEDELAYEDEXPANSION
+PUSHD %~dp0
 
 SET model=%1
 IF "%model%"=="" SET model=x64
@@ -10,6 +11,7 @@ CALL tools\buildAndTest.cmd release %model% || GOTO error
 IF EXIST output\NuXJScript_release_%model%.exe (
 	MOVE /Y output\NuXJScript_release_%model%.exe output\NuXJScript.exe >NUL
 )
+POPD
 EXIT /b 0
 
 :error

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e -o pipefail
+set -e -o pipefail -u
 cd "$(dirname "$0")"
 
 model=${1:-native}


### PR DESCRIPTION
## Summary
- update `build.sh` to enable `-u`
- make `build.cmd` pushd/popd around build logic

## Testing
- `timeout 180 ./build.sh` *(fails: timeout)*

------
https://chatgpt.com/codex/tasks/task_e_6872af482d008332a6b29bae2d9e210f