### PR TITLE
Unwrap markdown text

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,23 +37,21 @@ Key style points:
 - Line continuations should start with the operator and be indented two tabs from the original line.
 - `#if`/`#endif` blocks should appear one tab *left* of the current indentation level.
 - Class comment – put a plain C-style block comment immediately above each class, *not* Doxygen.  
-	```
-	/**
-		One-sentence summary of what the class does.
-		Extra details if truly needed.
-	**/
-	```
+       ```
+       /**
+               One-sentence summary of what the class does.
+               Extra details if truly needed.
+       **/
+       ```
 	* The two asterisks open/close the block; everything inside is indented with one tab.  
 - Small method comment – use a single end-of-line comment:  
 	void blahblah(int blah);	/// brief description of `blahblah`
 - Inside comment text, wrap any variable, parameter, class or function names in back-ticks, e.g. `blah` is the temporary buffer.
 
-See `docs/NuXJS Documentation.md` for details on how `src/stdlib.js` is
-minified and converted to `src/stdlibJS.cpp` during the build.
+See `docs/NuXJS Documentation.md` for details on how `src/stdlib.js` is minified and converted to `src/stdlibJS.cpp` during the build.
 
 ## Script portability
-All user-facing `.sh` and `.cmd` files must work when launched from any directory. They should start by changing
-to their own folder (or the repository root) so that relative paths resolve correctly.
+All user-facing `.sh` and `.cmd` files must work when launched from any directory. They should start by changing to their own folder (or the repository root) so that relative paths resolve correctly.
 
 `.sh` scripts must be runnable without requiring `chmod +x`; always invoke them with `bash path/to/script.sh` (do
 **not** rely on the system-default `sh`).  Each script must start with a portable she-bang:
@@ -75,8 +73,7 @@ REM example for a .cmd script
 CD /D "%~dp0\.."
 ```
 
-For robust error handling, `.sh` scripts should begin as shown above, and `.cmd`
-scripts normally use a simple error check:
+For robust error handling, `.sh` scripts should begin as shown above, and `.cmd` scripts normally use a simple error check:
 
 ```
 CALL buildAndTest.cmd %target% || GOTO error

--- a/README.md
+++ b/README.md
@@ -21,9 +21,7 @@ A sandboxed, single C++ source-file JavaScript engine in vanilla C++03 with fine
 
 ## Why ECMAScript 3?
 
-ECMAScript 3 was the first broadly adopted JS standard; it provides everything needed in a *scripting* language without
-a large runtime or a complex compiler. Staying with ES3 keeps the engine tiny and predictable. Selective ES5 features are
-“back-ported” where they add clear value:
+ECMAScript 3 was the first broadly adopted JS standard; it provides everything needed in a *scripting* language without a large runtime or a complex compiler. Staying with ES3 keeps the engine tiny and predictable. Selective ES5 features are “back-ported” where they add clear value:
 
 - Character indexing on `String` via `str[i]`
 - `JSON` support

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -13,21 +13,16 @@ Use `PikaCmd` to run the script:
 - `<test(s)>` is a file name or glob pattern for the benchmarks.
   Use `-` or omit the parameter to run every `*.js` file.
 - `<exe>|<rev-range>|makegold` can be the path to the
-  already compiled `NuXJScript` binary, a single revision number or
-  revision range (e.g. `12345-12350`) checked out and built prior to
-  running, or the literal `makegold` to generate reference output.
+  already compiled `NuXJScript` binary, a single revision number or revision range (e.g. `12345-12350`) checked out and built prior to running, or the literal `makegold` to generate reference output.
 - `ignoregold` is optional and skips output comparison.
 
 ## Golden results
 
-Benchmark output is normally checked against the files in
-`benchmarks/golden/`.  Differences create `failed.txt` and
-`expected.txt` in the current directory.
+Benchmark output is normally checked against the files in `benchmarks/golden/`.  Differences create `failed.txt` and `expected.txt` in the current directory.
 
 ## Building the engine for benchmarking
 
-Compile the binary using the regular `./build.sh` wrapper or call the
-low-level helper directly:
+Compile the binary using the regular `./build.sh` wrapper or call the low-level helper directly:
 
 ```
 bash tools/BuildCpp.sh release x64 ./output/NuXJScript \


### PR DESCRIPTION
## Summary
- restore class comment format in AGENTS instructions
- confirmed markdown changes are whitespace-only by stripping whitespace before comparison

## Testing
- `timeout 180 ./build.sh`


------
https://chatgpt.com/codex/tasks/task_e_687cc37ca718833297677c0eb008462f