### PR TITLE
Add REPL help command

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ Both the **beta** and **release** targets are compiled with optimizations enable
 
 During this process, `src/stdlib.js` is minified and converted into `src/stdlibJS.cpp`. See `docs/NuXJS Documentation.md` for details.
 
+The build outputs a console REPL named `NuXJScript`. Type `help()` inside the REPL to
+see available helper functions and commands. Use `#save` to capture the current session
+as a `.io` file. When no name is given, the REPL creates a timestamped file in
+`tests/` so it can immediately be used as a regression case.
+
 ## Example
 
 Here’s a minimal example of embedding NuXJS using the high-level API:

--- a/docs/NuXJS Documentation.md
+++ b/docs/NuXJS Documentation.md
@@ -20,6 +20,16 @@ The implementation depends on IEEE-compliant floating-point math. `src/NuXJScrip
 
 The standard library lives in `src/stdlib.js`. During the build, it is minified and converted to C++ via `tools/stdlibToCpp.pika` using `PikaCmd`. The build scripts automatically regenerate `src/stdlibJS.cpp` when `stdlib.js` changes.
 
+## Using the REPL
+
+Building NuXJS produces a command line REPL named `NuXJScript`. Inside the REPL,
+`help()` lists the available helper functions and meta commands. Custom helpers
+include `read(file)`, `load(file)`, `quit()`, `gc()` and `dasm(fn)`. Meta
+commands start with `#` and currently support `#save [name]` to write the session
+log and `#purge` to clear it. `#save` without a name uses a timestamp for the
+file name and saves the `.io` file directly into `tests/` so it can be added as
+a regression case. Prefixing a line with `?` runs `print()` on that expression.
+
 ## Embedding NuXJS
 
 The high-level C++ API allows easy embedding of the interpreter into an existing application. Functions exposed to JavaScript typically have the signature `Var func(Runtime& rt, const Var& thisVar, const VarList& args)` and are stored in the global object like any other value. Source code may be executed with `Runtime::run()` or evaluated with `Runtime::eval()`.

--- a/tools/NuXJSREPL.cpp
+++ b/tools/NuXJSREPL.cpp
@@ -381,8 +381,25 @@ Var load(Runtime& rt, const Var& thisVar, const VarList& args) {
 bool doQuit = false;
 
 Var quit(Runtime& rt, const Var& thisVar, const VarList& args) {
-	doQuit = true;
-	return Var(rt);
+        doQuit = true;
+        return Var(rt);
+}
+
+Var help(Runtime& rt, const Var& thisVar, const VarList& args) {
+        (void)thisVar;
+        (void)args;
+        std::wcout << L"Available REPL helpers:" << std::endl
+                        << L"  read(file)   - return UTF-8 file as string" << std::endl
+                        << L"  load(file)   - execute a UTF-8 JavaScript file" << std::endl
+                        << L"  quit()       - exit the REPL" << std::endl
+                        << L"  gc()         - run garbage collection" << std::endl
+                        << L"  dasm(func)   - disassemble a compiled function" << std::endl
+                        << L"Special commands:" << std::endl
+                        << L"  #save [name] - save the current session" << std::endl
+                        << L"                 (no name uses a timestamp in tests/)" << std::endl
+                        << L"  #purge       - clear the session log" << std::endl
+                        << L"  ?expr        - shortcut for print(expr)" << std::endl;
+        return Var(rt);
 }
 
 struct MyHeap : public Heap {
@@ -486,9 +503,10 @@ int testMain(int argc, const char* argv[]) {
 
 		Object& globals = *rt.getGlobalObject();
 		Var globs = rt.getGlobalsVar();
-		globs["read"] = read;
-		globs["load"] = load;
-		globs["quit"] = quit;
+                globs["read"] = read;
+                globs["load"] = load;
+                globs["quit"] = quit;
+                globs["help"] = help;
 
 		PrintFunction printFunction;
 		globals.setOwnProperty(rt, &PRINT_STRING, &printFunction, DONT_ENUM_FLAG);
@@ -668,7 +686,7 @@ int testMain(int argc, const char* argv[]) {
 				pushIOStop();
 			}
 		}
-		if (interactive && !inStream->eof()) {
+		if (interactive && !doQuit && !inStream->eof()) {
 			std::cout << "input stream failure" << std::endl;
 			return 1;
 		}


### PR DESCRIPTION
## Summary
- add `help()` command in the REPL and export it on the globals
- document REPL helpers and meta commands
- mention REPL help in README
- describe how `#save` ties into regression tests
- document `#save` without a name uses a timestamp and goes into tests/
- clarify docs about `#save` naming

## Testing
- `timeout 180 ./build.sh` *(failed to finish within 180s)*

------
https://chatgpt.com/codex/tasks/task_e_687e6c00ef408332921ae99eba1f60e7