### PR TITLE
Revert TestDash harness changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,3 @@ externals/PikaCmd/PikaCmd
 /projects/.vs
 /temp
 externals/PikaCmd/PikaCmd.exe
-/test262-master/
-/externals/test262-master.tar.gz


### PR DESCRIPTION
## Summary
- roll back test runner to pre-tarball design that fetches Test262 at runtime
- restore non-JSON output handling in TestDash harness

## Testing
- `timeout 180 ./build.sh`
- `node tools/testdash.node.js --cli --limit 100`


------
https://chatgpt.com/codex/tasks/task_e_68ac3c5e5ff4833288281dd7b64fe0fc