### PR TITLE
Use current node binary for test harness

### DIFF
--- a/tools/testdash.node.js
+++ b/tools/testdash.node.js
@@ -80,7 +80,7 @@ function runTests(callback, limit) {
 		args.push("test/language/**/*.js");
 	}
 
-       var child = child_process.spawn("node", [harness].concat(args), { cwd: TEST_PATH });
+	var child = child_process.spawn(process.execPath, [harness].concat(args), { cwd: TEST_PATH });
        child.stdout.setEncoding("utf8");
        readline.createInterface({ input: child.stdout }).on("line", (line) => {
                line = line.trim();


### PR DESCRIPTION
## Summary
- ensure Test262 harness runs with the same Node binary that invokes testdash

## Testing
- `node tools/testdash.node.js --cli --limit 2`
- `timeout 180 ./build.sh`

------
https://chatgpt.com/codex/tasks/task_e_68ac9097f69083328b469165b9c5f083