### PR TITLE
Skip ES5 tests for ES3 builds

### DIFF
--- a/tools/buildAndTest.cmd
+++ b/tools/buildAndTest.cmd
@@ -54,7 +54,14 @@ CALL .\BuildCpp.cmd %target% %model% ..\output\NuXJSTest_%target%_%model%.exe .\
 ..\output\NuXJSTest_%target%_%model% -s >NUL 2>&1 || GOTO error
 ..\output\NuXJSTest_%target%_%model% || GOTO error
 CALL .\BuildCpp.cmd %target% %model% ..\output\NuXJS_%target%_%model%.exe .\NuXJSREPL.cpp ..\src\NuXJS.cpp ..\src\stdlibJS.cpp || GOTO error
-..\externals\PikaCmd\PikaCmd.exe .\test.pika -e -x ..\output\NuXJS_%target%_%model% ..\tests\ || GOTO error
+REM Select test directories; include ES5 tests only when ES5 is enabled.
+ECHO %CPP_OPTIONS% | FINDSTR /C:"/DNUXJS_ES5=1" >NUL
+IF ERRORLEVEL 1 (
+    SET TEST_DIRS=..\tests\conforming ..\tests\erroneous ..\tests\es3only ..\tests\extremes ..\tests\from262 ..\tests\migrated ..\tests\regression ..\tests\stdlib ..\tests\unconforming ..\tests\unsorted
+) ELSE (
+    SET TEST_DIRS=..\tests\conforming ..\tests\erroneous ..\tests\es3only ..\tests\es5 ..\tests\extremes ..\tests\from262 ..\tests\migrated ..\tests\regression ..\tests\stdlib ..\tests\unconforming ..\tests\unsorted
+)
+..\externals\PikaCmd\PikaCmd.exe .\test.pika -e -x ..\output\NuXJS_%target%_%model% %TEST_DIRS% || GOTO error
 CALL runExamples.cmd %target% || GOTO error
 ECHO Success!
 POPD

--- a/tools/buildAndTest.sh
+++ b/tools/buildAndTest.sh
@@ -63,7 +63,13 @@ bash ./BuildCpp.sh $target $model ../output/NuXJSTest_${target}_${model} ../tool
 ../output/NuXJSTest_${target}_${model} -s >/dev/null 2>&1
 ../output/NuXJSTest_${target}_${model}
 bash ./BuildCpp.sh $target $model ../output/NuXJS_${target}_${model} ../tools/NuXJSREPL.cpp ../src/NuXJS.cpp ../src/stdlibJS.cpp
-../externals/PikaCmd/PikaCmd ./test.pika -e -x ../output/NuXJS_${target}_${model} ../tests/
+# Select test directories; include ES5 tests only when ES5 is enabled.
+if echo " ${CPP_OPTIONS-} " | grep -q -- "-DNUXJS_ES5=1"; then
+	TEST_DIRS=(../tests/conforming ../tests/erroneous ../tests/es3only ../tests/es5 ../tests/extremes ../tests/from262 ../tests/migrated ../tests/regression ../tests/stdlib ../tests/unconforming ../tests/unsorted)
+else
+	TEST_DIRS=(../tests/conforming ../tests/erroneous ../tests/es3only ../tests/extremes ../tests/from262 ../tests/migrated ../tests/regression ../tests/stdlib ../tests/unconforming ../tests/unsorted)
+fi
+../externals/PikaCmd/PikaCmd ./test.pika -e -x ../output/NuXJS_${target}_${model} "${TEST_DIRS[@]}"
 bash ./runExamples.sh "$target"
 
 echo Success!


### PR DESCRIPTION
## Summary
- Avoid running ES5 test cases when NuXJS is built without ES5 support

## Testing
- `timeout 180 ./build.sh` *(fails: Cannot open file for reading: '/tmp/PikaTemp381AA516/stdout')*

------
https://chatgpt.com/codex/tasks/task_e_68b042e15204833290b03ffea6c34111