### PR TITLE
docs: add standard library guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ Key style points:
 	void blahblah(int blah);	/// brief description of `blahblah`
 - Inside comment text, wrap any variable, parameter, class or function names in back-ticks, e.g. `blah` is the temporary buffer.
 
-See `docs/NuXJS Documentation.md` for details on how `src/stdlib.js` is minified and converted to `src/stdlibJS.cpp` during the build.
+See `docs/NuXJS Documentation.md` for details on how `src/stdlib.js` is minified and converted to `src/stdlibJS.cpp` during the build, and `docs/Standard Library Guidelines.md` for rules when editing the standard library.
 
 ## Script portability
 All user-facing `.sh` and `.cmd` files must work when launched from any directory. They should start by changing to their own folder (or the repository root) so that relative paths resolve correctly.

--- a/docs/NuXJS Documentation.md
+++ b/docs/NuXJS Documentation.md
@@ -18,7 +18,10 @@ This wrapper builds and tests both the `beta` and `release` configurations by in
 
 The implementation depends on IEEE-compliant floating-point math. `src/NuXJS.cpp` includes `#error` directives that trigger if `__FAST_MATH__` is defined. Avoid compiler flags like `-Ofast`, `-ffast-math`, or similar, at least for `src/NuXJS.cpp`.
 
-The standard library lives in `src/stdlib.js`. During the build, it is minified and converted to C++ via `tools/stdlibToCpp.pika` using `PikaCmd`. The build scripts automatically regenerate `src/stdlibJS.cpp` when `stdlib.js` changes.
+The standard library lives in `src/stdlib.js`.
+During the build, it is minified and converted to C++ via `tools/stdlibToCpp.pika` using `PikaCmd`.
+The build scripts automatically regenerate `src/stdlibJS.cpp` when `stdlib.js` changes.
+See `Standard Library Guidelines.md` for rules on modifying this file.
 
 ## Using the REPL
 

--- a/docs/Standard Library Guidelines.md
+++ b/docs/Standard Library Guidelines.md
@@ -1,0 +1,23 @@
+# Standard Library Guidelines
+
+The standard library lives in `src/stdlib.js`. After editing it, run `./build.sh` to regenerate `src/stdlibJS.cpp` and execute the regression tests.
+
+## Formatting and style
+- Follow repository formatting rules: tabs for indentation, braces on the same line and a 120-character limit.
+- Add identifiers that must survive minification to the `@preserve` block at the top of `src/stdlib.js`.
+
+## Engine interaction
+- Interact with the engine only through the injected `support` object, using helpers like `defineProperty`, `callWithArgs` and `getInternalProperty`.
+- Use `defineProperties` to apply `readOnly`, `dontEnum` and `dontDelete` attributes consistently.
+
+## Avoid global objects
+- Do not rely on global constructors or methods because user code may reassign them.
+- Use the `$`-prefixed helpers or functions on `support` instead of global versions (for example `$charCodeAt`, `$isNaN`).
+
+## Unconstructable methods
+- Wrap functions that must not be invoked with `new` using `unconstructable` (an alias for `support.distinctConstructor`).
+- This removes their `.prototype` property and throws a `TypeError` when construction is attempted.
+
+## Language constraints
+- Target ECMAScript 3 semantics.
+- Avoid engine limitations such as custom getters/setters, non-ES3 evaluation order and unsupported regular expression features.


### PR DESCRIPTION
## Summary
- Introduce dedicated Standard Library Guidelines doc detailing formatting, support APIs, safe `$` helpers, and the `unconstructable` wrapper.
- Reference the new guide from NuXJS Documentation and repository AGENTS instructions.

## Testing
- `timeout 180 ./build.sh`

------
https://chatgpt.com/codex/tasks/task_e_68b1536b36908332974ff12cfe5abb68