### PR TITLE
Simplify build scripts with ES variant argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,26 +110,17 @@ Notes:
 
 ## ES3 vs ES5.1 Builds
 
-This branch layers an ES5.1 feature set on top of the stable ES3 core. ES5.1 is controlled by the `NUXJS_ES5` compile‑time switch and is enabled by default.
+This branch layers an ES5.1 feature set on top of the stable ES3 core.
 
-- Default (ES5.1): run `./build.sh` (or `build.cmd`). All tests, including ES5.1, are executed.
-- ES3-only variant: set `NUXJS_ES5=0` via `CPP_OPTIONS` to disable ES5.1 features and tests.
-  - macOS/Linux: `CPP_OPTIONS='-DNUXJS_ES5=0' ./build.sh`
-  - Windows (PowerShell): `$env:CPP_OPTIONS='/DNUXJS_ES5=0'; ./build.cmd`
-  - Windows (cmd): `SET CPP_OPTIONS=/DNUXJS_ES5=0 && build.cmd`
+`build.sh` and `build.cmd` accept an optional first argument selecting the ECMAScript variant:
 
-### Test Both Variants (ES3 and ES5.1)
+- `es5` – build and test with ES5.1 features enabled.
+- `es3` – disable ES5.1 features and tests.
+- `both` (default) – run the full suite for both ES3 and ES5.1.
 
-- Two‑pass mode: set `NUXJS_TEST_ES5_VARIANTS=1` to build and run the full suite twice (first with ES3, then with ES5.1):
-  - `NUXJS_TEST_ES5_VARIANTS=1 ./build.sh`
-- Faster inner loop: when using two‑pass mode during development, skip the release target:
-  - macOS/Linux: `NUXJS_SKIP_RELEASE=1 NUXJS_TEST_ES5_VARIANTS=1 ./tools/buildAndTest.sh beta`
-  - Windows (cmd): `SET NUXJS_SKIP_RELEASE=1 & SET NUXJS_TEST_ES5_VARIANTS=1 & tools\buildAndTest.cmd beta`
+A second argument may specify the model (e.g. architecture); it defaults to `native` on Unix and `x64` on Windows.
 
-Notes:
-
-- In single‑pass builds, ES5 tests run by default. To skip them, compile with `-DNUXJS_ES5=0`.
-- See `docs/ES5.1 Roadmap.md` for current coverage, open items, and semantic notes (e.g. `Function.prototype.bind`, strict mode, accessors, and `Object.create`/`Object.defineProperties`).
+See `docs/ES5.1 Roadmap.md` for current coverage, open items, and semantic notes (e.g. `Function.prototype.bind`, strict mode, accessors, and `Object.create`/`Object.defineProperties`).
 
 ## Example
 

--- a/build.cmd
+++ b/build.cmd
@@ -2,7 +2,19 @@
 SETLOCAL ENABLEEXTENSIONS ENABLEDELAYEDEXPANSION
 PUSHD %~dp0
 
-SET model=%1
+SET variant=%1
+SET model=%2
+
+IF /I "%variant%"=="es3" (
+	SET CPP_OPTIONS=%CPP_OPTIONS% /DNUXJS_ES5=0
+) ELSE IF /I "%variant%"=="es5" (
+	SET CPP_OPTIONS=%CPP_OPTIONS% /DNUXJS_ES5=1
+) ELSE IF /I "%variant%"=="both" (
+	SET NUXJS_TEST_ES5_VARIANTS=1
+) ELSE (
+	SET model=%variant%
+)
+
 IF "%model%"=="" SET model=x64
 
 CALL tools\buildAndTest.cmd beta %model% || GOTO error

--- a/build.sh
+++ b/build.sh
@@ -2,12 +2,29 @@
 set -e -o pipefail -u
 cd "$(dirname "$0")"
 
-model=${1:-native}
+variant=${1:-both}
+model=${2:-native}
+
+case "$variant" in
+	es3|ES3)
+		export CPP_OPTIONS="${CPP_OPTIONS-} -DNUXJS_ES5=0"
+		;;
+	es5|ES5)
+		export CPP_OPTIONS="${CPP_OPTIONS-} -DNUXJS_ES5=1"
+		;;
+	both|BOTH)
+		export NUXJS_TEST_ES5_VARIANTS=1
+		;;
+	*)
+		model="$variant"
+		variant=both
+		;;
+esac
 
 for target in beta release; do
-        bash ./tools/buildAndTest.sh "$target" "$model"
+	bash ./tools/buildAndTest.sh "$target" "$model"
 done
 
 if [ -f "output/NuXJS_release_${model}" ]; then
-        mv -f "output/NuXJS_release_${model}" "output/NuXJS"
+	mv -f "output/NuXJS_release_${model}" "output/NuXJS"
 fi


### PR DESCRIPTION
## Summary
- allow `build.sh` and `build.cmd` to take an ES variant argument (`es3`, `es5`, `both`)
- update README to document the simpler variant selection

## Testing
- `timeout 600 ./build.sh es5`

------
https://chatgpt.com/codex/tasks/task_e_68b2dc92a6708332b2e254fbf698fef8