### PR TITLE
Refactor build scripts to share ES variant logic

### DIFF
--- a/tools/buildAndTest.cmd
+++ b/tools/buildAndTest.cmd
@@ -15,55 +15,21 @@ CALL .\BuildPikaCmd.cmd || GOTO error
 POPD
 ..\externals\PikaCmd\PikaCmd.exe .\stdlibToCpp.pika ..\src\stdlib.js ..\src\stdlibJS.cpp || GOTO error
 
-REM Optional dual-variant test mode (ES3 and ES5) — default OFF if not set
-IF "%NUXJS_TEST_ES5_VARIANTS%"=="" SET NUXJS_TEST_ES5_VARIANTS=0
+REM Optional dual-variant test mode
 IF "%NUXJS_TEST_ES5_VARIANTS%"=="1" (
 	IF /I "%target%"=="release" IF "%NUXJS_SKIP_RELEASE%"=="1" (
 		ECHO Skipping release per NUXJS_SKIP_RELEASE=1
 		POPD
 		EXIT /b 0
 	)
-
-	SET CPP_OPTIONS_BASE=%CPP_OPTIONS%
-	MKDIR ..\output >NUL 2>&1
 	FOR %%E IN (0 1) DO (
 		ECHO Building and testing with NUXJS_ES5=%%E (%target% %model%)
-		SET CPP_OPTIONS=%CPP_OPTIONS_BASE% /DNUXJS_ES5=%%E
-		IF /I "%target%"=="release" SET CPP_OPTIONS=/GR- %CPP_OPTIONS%
-		CALL .\BuildCpp.cmd %target% %model% ..\output\NuXJSTest_%target%_%model%.exe .\NuXJSTest.cpp ..\src\NuXJS.cpp ..\src\stdlibJS.cpp || GOTO error
-		..\output\NuXJSTest_%target%_%model% -s >NUL 2>&1 || GOTO error
-		..\output\NuXJSTest_%target%_%model% || GOTO error
-		CALL .\BuildCpp.cmd %target% %model% ..\output\NuXJS_%target%_%model%.exe .\NuXJSREPL.cpp ..\src\NuXJS.cpp ..\src\stdlibJS.cpp || GOTO error
-		IF "%%E"=="1" (
-			SET TEST_DIRS=..\tests\conforming\ ..\tests\erroneous\ ..\tests\es3only\ ..\tests\es5\ ..\tests\extremes\ ..\tests\from262\ ..\tests\migrated\ ..\tests\regression\ ..\tests\stdlib\ ..\tests\unconforming\ ..\tests\unsorted\
-		) ELSE (
-			SET TEST_DIRS=..\tests\conforming\ ..\tests\erroneous\ ..\tests\es3only\ ..\tests\extremes\ ..\tests\migrated\ ..\tests\regression\ ..\tests\stdlib\ ..\tests\unconforming\ ..\tests\unsorted\
-		)
-		..\externals\PikaCmd\PikaCmd.exe .\test.pika -e -x ..\output\NuXJS_%target%_%model% %TEST_DIRS% || GOTO error
-		CALL runExamples.cmd %target% || GOTO error
-		ECHO Done NUXJS_ES5=%%E (%target% %model%)
+		CALL .\buildAndTestOne.cmd %target% %model% %%E || GOTO error
 	)
-	ECHO Success!
-	POPD
-	EXIT /b 0
+) ELSE (
+	CALL .\buildAndTestOne.cmd %target% %model% || GOTO error
 )
 
-REM Default single-pass build and test
-IF /I "%target%"=="release" SET CPP_OPTIONS=/GR- %CPP_OPTIONS%
-MKDIR ..\output >NUL 2>&1
-CALL .\BuildCpp.cmd %target% %model% ..\output\NuXJSTest_%target%_%model%.exe .\NuXJSTest.cpp ..\src\NuXJS.cpp ..\src\stdlibJS.cpp || GOTO error
-..\output\NuXJSTest_%target%_%model% -s >NUL 2>&1 || GOTO error
-..\output\NuXJSTest_%target%_%model% || GOTO error
-CALL .\BuildCpp.cmd %target% %model% ..\output\NuXJS_%target%_%model%.exe .\NuXJSREPL.cpp ..\src\NuXJS.cpp ..\src\stdlibJS.cpp || GOTO error
-REM Select test directories; exclude ES5 tests only when explicitly disabled with /DNUXJS_ES5=0
-ECHO %CPP_OPTIONS% | FINDSTR /C:"/DNUXJS_ES5=0" >NUL
-IF ERRORLEVEL 0 (
-	SET TEST_DIRS=..\tests\conforming\ ..\tests\erroneous\ ..\tests\es3only\ ..\tests\extremes\..\tests\migrated\ ..\tests\regression\ ..\tests\stdlib\ ..\tests\unconforming\ ..\tests\unsorted
-) ELSE (
-	SET TEST_DIRS=..\tests\conforming\ ..\tests\erroneous\ ..\tests\es3only\ ..\tests\es5\ ..\tests\extremes\ ..\tests\from262\ ..\tests\migrated\ ..\tests\regression\ ..\tests\stdlib\ ..\tests\unconforming\ ..\tests\unsorted
-)
-..\externals\PikaCmd\PikaCmd.exe .\test.pika -e -x\ ..\output\NuXJS_%target%_%model% %TEST_DIRS% || GOTO error
-CALL runExamples.cmd %target% || GOTO error
 ECHO Success!
 POPD
 EXIT /b 0

--- a/tools/buildAndTest.sh
+++ b/tools/buildAndTest.sh
@@ -2,8 +2,8 @@
 set -e -o pipefail -u
 cd "$(dirname "$0")"
 
-target=${1-debug}
-model=${2-x64}
+target=${1:-debug}
+model=${2:-x64}
 
 # Build PikaCmd tools and update stdlibJS.cpp if needed (once per invocation)
 cd ../externals/PikaCmd
@@ -12,7 +12,6 @@ if [ ! -e ./PikaCmd ]; then
 fi
 bash ./BuildPikaCmd.sh
 cd ../../tools
-# Rebuild stdlibJS.cpp when any relevant source changed (base stdlib, ES5 extras, or the minifier pipeline).
 if [ "../src/stdlib.js" -nt "../src/stdlibJS.cpp" ] || \
    [ "../src/stdlibES5.js" -nt "../src/stdlibJS.cpp" ] || \
    [ "./stdlibToCpp.pika" -nt "../src/stdlibJS.cpp" ] || \
@@ -20,57 +19,17 @@ if [ "../src/stdlib.js" -nt "../src/stdlibJS.cpp" ] || \
 	../externals/PikaCmd/PikaCmd ./stdlibToCpp.pika ../src/stdlib.js ../src/stdlibJS.cpp
 fi
 
-# When NUXJS_TEST_ES5_VARIANTS=1, run tests twice with NUXJS_ES5=0 and 1.
 if [ "${NUXJS_TEST_ES5_VARIANTS-0}" = "1" ]; then
-	# Optionally skip release target to speed up dev iterations.
 	if [ "$target" = "release" ] && [ "${NUXJS_SKIP_RELEASE-0}" = "1" ]; then
 		echo "Skipping release per NUXJS_SKIP_RELEASE=1"
 		exit 0
 	fi
-
-	CPP_OPTIONS_BASE="${CPP_OPTIONS-}"
-	mkdir ../output >/dev/null 2>&1 || true
 	for es5 in 0 1; do
 		echo "Building and testing with NUXJS_ES5=${es5} ($target $model)"
-		export CPP_OPTIONS="${CPP_OPTIONS_BASE} -DNUXJS_ES5=${es5}"
-		if [ "$target" == "release" ]; then
-			export CPP_OPTIONS="-fno-rtti ${CPP_OPTIONS}"
-		fi
-		bash ./BuildCpp.sh $target $model ../output/NuXJSTest_${target}_${model} ../tools/NuXJSTest.cpp ../src/NuXJS.cpp ../src/stdlibJS.cpp
-		../output/NuXJSTest_${target}_${model} -s >/dev/null 2>&1
-		../output/NuXJSTest_${target}_${model}
-		bash ./BuildCpp.sh $target $model ../output/NuXJS_${target}_${model} ../tools/NuXJSREPL.cpp ../src/NuXJS.cpp ../src/stdlibJS.cpp
-		# Select test directories; include ES5 tests only when ES5 is enabled.
-			if [ "$es5" = "1" ]; then
-					TEST_DIRS=(../tests/conforming/ ../tests/erroneous/ ../tests/es3only/ ../tests/es5/ ../tests/extremes/ ../tests/from262/ ../tests/migrated/ ../tests/regression/ ../tests/stdlib/ ../tests/unconforming/ ../tests/unsorted/)
-			else
-					TEST_DIRS=(../tests/conforming/ ../tests/erroneous/ ../tests/es3only/ ../tests/extremes/ ../tests/migrated/ ../tests/regression/ ../tests/stdlib/ ../tests/unconforming/ ../tests/unsorted/)
-			fi
-		../externals/PikaCmd/PikaCmd ./test.pika -e -x ../output/NuXJS_${target}_${model} "${TEST_DIRS[@]}"
-		bash ./runExamples.sh "$target"
-		echo "Done NUXJS_ES5=${es5} ($target $model)"
+		bash ./buildAndTestOne.sh "$target" "$model" "$es5"
 	done
-	echo Success!
-	exit 0
-fi
-
-# Default single-pass build and test
-if [ "$target" == "release" ]; then
-	export CPP_OPTIONS="-fno-rtti ${CPP_OPTIONS-}"
-fi
-mkdir ../output >/dev/null 2>&1 || true
-bash ./BuildCpp.sh $target $model ../output/NuXJSTest_${target}_${model} ../tools/NuXJSTest.cpp ../src/NuXJS.cpp ../src/stdlibJS.cpp
-../output/NuXJSTest_${target}_${model} -s >/dev/null 2>&1
-../output/NuXJSTest_${target}_${model}
-bash ./BuildCpp.sh $target $model ../output/NuXJS_${target}_${model} ../tools/NuXJSREPL.cpp ../src/NuXJS.cpp ../src/stdlibJS.cpp
-
-# Select test directories; exclude ES5 tests only when explicitly disabled with -DNUXJS_ES5=0.
-if echo " ${CPP_OPTIONS-} " | grep -q -- "-DNUXJS_ES5=0"; then
-	TEST_DIRS=(../tests/conforming/ ../tests/erroneous/ ../tests/es3only/ ../tests/extremes/ ../tests/migrated/ ../tests/regression/ ../tests/stdlib/ ../tests/unconforming/ ../tests/unsorted)
 else
-	TEST_DIRS=(../tests/conforming/ ../tests/erroneous/ ../tests/es3only/ ../tests/es5/ ../tests/extremes/ ../tests/from262/ ../tests/migrated/ ../tests/regression/ ../tests/stdlib/ ../tests/unconforming/ ../tests/unsorted)
+	bash ./buildAndTestOne.sh "$target" "$model"
 fi
-../externals/PikaCmd/PikaCmd ./test.pika -e -x ../output/NuXJS_${target}_${model} "${TEST_DIRS[@]}"
-bash ./runExamples.sh "$target"
 
 echo Success!

--- a/tools/buildAndTestOne.cmd
+++ b/tools/buildAndTestOne.cmd
@@ -1,0 +1,49 @@
+@ECHO OFF
+SETLOCAL ENABLEEXTENSIONS ENABLEDELAYEDEXPANSION
+
+PUSHD %~dp0
+
+SET target=%~1
+SET model=%~2
+SET es5=%~3
+IF "%target%"=="" SET target=debug
+IF "%model%"=="" SET model=x64
+IF "%CPP_OPTIONS%"=="" SET CPP_OPTIONS=/FS
+IF /I "%target%"=="release" SET CPP_OPTIONS=/GR- %CPP_OPTIONS%
+IF NOT "%es5%"=="" SET CPP_OPTIONS=%CPP_OPTIONS% /DNUXJS_ES5=%es5%
+
+MKDIR ..\output >NUL 2>&1
+
+CALL .\BuildCpp.cmd %target% %model% ..\output\NuXJSTest_%target%_%model%.exe .\NuXJSTest.cpp ..\src\NuXJS.cpp ..\src\stdlibJS.cpp || GOTO error
+..\output\NuXJSTest_%target%_%model% -s >NUL 2>&1 || GOTO error
+..\output\NuXJSTest_%target%_%model% || GOTO error
+CALL .\BuildCpp.cmd %target% %model% ..\output\NuXJS_%target%_%model%.exe .\NuXJSREPL.cpp ..\src\NuXJS.cpp ..\src\stdlibJS.cpp || GOTO error
+
+IF NOT "%es5%"=="" (
+	SET es5_enabled=%es5%
+) ELSE (
+	ECHO %CPP_OPTIONS% | FINDSTR /C:"/DNUXJS_ES5=0" >NUL
+	IF ERRORLEVEL 1 (
+		SET es5_enabled=1
+	) ELSE (
+		SET es5_enabled=0
+	)
+)
+
+SET TEST_DIRS=..\tests\conforming\ ..\tests\erroneous\ ..\tests\es3only\
+IF "%es5_enabled%"=="1" SET TEST_DIRS=%TEST_DIRS% ..\tests\es5\
+SET TEST_DIRS=%TEST_DIRS% ..\tests\extremes\
+IF "%es5_enabled%"=="1" SET TEST_DIRS=%TEST_DIRS% ..\tests\from262\
+SET TEST_DIRS=%TEST_DIRS% ..\tests\migrated\ ..\tests\regression\ ..\tests\stdlib\ ..\tests\unconforming\ ..\tests\unsorted\
+
+..\externals\PikaCmd\PikaCmd.exe .\test.pika -e -x ..\output\NuXJS_%target%_%model% %TEST_DIRS% || GOTO error
+CALL runExamples.cmd %target% || GOTO error
+
+IF NOT "%es5%"=="" ECHO Done NUXJS_ES5=%es5% (%target% %model%)
+
+POPD
+EXIT /b 0
+
+:error
+POPD
+EXIT /b %ERRORLEVEL%

--- a/tools/buildAndTestOne.sh
+++ b/tools/buildAndTestOne.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -e -o pipefail -u
+cd "$(dirname "$0")"
+
+target=${1:-debug}
+model=${2:-x64}
+es5=${3-}
+
+if [[ "$target" == "release" ]]; then
+	CPP_OPTIONS="-fno-rtti ${CPP_OPTIONS-}"
+fi
+if [[ -n "$es5" ]]; then
+	CPP_OPTIONS="${CPP_OPTIONS-} -DNUXJS_ES5=${es5}"
+fi
+
+export CPP_OPTIONS
+
+mkdir ../output >/dev/null 2>&1 || true
+bash ./BuildCpp.sh "$target" "$model" ../output/NuXJSTest_${target}_${model} ./NuXJSTest.cpp ../src/NuXJS.cpp ../src/stdlibJS.cpp
+../output/NuXJSTest_${target}_${model} -s >/dev/null 2>&1
+../output/NuXJSTest_${target}_${model}
+bash ./BuildCpp.sh "$target" "$model" ../output/NuXJS_${target}_${model} ./NuXJSREPL.cpp ../src/NuXJS.cpp ../src/stdlibJS.cpp
+
+if [[ -n "$es5" ]]; then
+	ES5_ENABLED="$es5"
+else
+	if echo " ${CPP_OPTIONS-} " | grep -q -- "-DNUXJS_ES5=0"; then
+		ES5_ENABLED=0
+	else
+		ES5_ENABLED=1
+	fi
+fi
+
+TEST_DIRS=(../tests/conforming/ ../tests/erroneous/ ../tests/es3only/)
+if [[ "$ES5_ENABLED" == "1" ]]; then
+	TEST_DIRS+=(../tests/es5/)
+fi
+TEST_DIRS+=(../tests/extremes/)
+if [[ "$ES5_ENABLED" == "1" ]]; then
+	TEST_DIRS+=(../tests/from262/)
+fi
+TEST_DIRS+=(../tests/migrated/ ../tests/regression/ ../tests/stdlib/ ../tests/unconforming/ ../tests/unsorted/)
+
+../externals/PikaCmd/PikaCmd ./test.pika -e -x ../output/NuXJS_${target}_${model} "${TEST_DIRS[@]}"
+bash ./runExamples.sh "$target"
+
+if [[ -n "$es5" ]]; then
+	echo "Done NUXJS_ES5=${es5} (${target} ${model})"
+fi


### PR DESCRIPTION
## Summary
- Extract repeated build/test logic into new `buildAndTestOne` scripts for single ES variant
- Simplify existing `buildAndTest` scripts to call the shared helper and handle optional dual-variant runs
- Correct ES5 detection in Windows helper and export `CPP_OPTIONS` in bash helper
- Deduplicate test directory selection in single-variant scripts by computing ES5 flag once

## Testing
- `timeout 600 ./build.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b56f6f8fbc8332a5c3d3120a8813bd