### PR TITLE
Mark non-ES3 test262 built-ins

### DIFF
--- a/tools/testdash.json
+++ b/tools/testdash.json
@@ -1,4593 +1,237 @@
 {
+	"annexB/built-ins/Date/prototype/getYear/B.2.4": {
+		"category": "not_es3"
+	},
+	"annexB/built-ins/Date/prototype/getYear/B.2.4.propertyCheck": {
+		"category": "not_es3"
+	},
+	"annexB/built-ins/Date/prototype/getYear/length": {
+		"category": "not_es3"
+	},
+	"annexB/built-ins/Date/prototype/getYear/name": {
+		"category": "not_es3"
+	},
+	"annexB/built-ins/Date/prototype/setYear/B.2.5": {
+		"category": "not_es3"
+	},
+	"annexB/built-ins/Date/prototype/setYear/B.2.5.propertyCheck": {
+		"category": "not_es3"
+	},
+	"annexB/built-ins/Date/prototype/setYear/length": {
+		"category": "not_es3"
+	},
+	"annexB/built-ins/Date/prototype/setYear/name": {
+		"category": "not_es3"
+	},
+	"annexB/built-ins/Date/prototype/toGMTString/B.2.6": {
+		"category": "not_es3"
+	},
+	"annexB/built-ins/Date/prototype/toGMTString/B.2.6.propertyCheck": {
+		"category": "not_es3"
+	},
+	"annexB/built-ins/Date/prototype/toGMTString/length": {
+		"category": "not_es3"
+	},
+	"annexB/built-ins/Date/prototype/toGMTString/name": {
+		"category": "not_es3"
+	},
+	"annexB/built-ins/Object/prototype/__proto__/B.2.2.1.1": {
+		"category": "not_es3"
+	},
+	"annexB/built-ins/Object/prototype/__proto__/B.2.2.1.2": {
+		"category": "not_es3"
+	},
+	"annexB/built-ins/RegExp/RegExp-control-escape-russian-letter": {
+		"category": "not_es3"
+	},
+	"annexB/built-ins/RegExp/RegExp-decimal-escape-class-range": {
+		"category": "not_es3"
+	},
+	"annexB/built-ins/RegExp/RegExp-decimal-escape-not-capturing": {
+		"category": "not_es3"
+	},
+	"annexB/built-ins/RegExp/RegExp-leading-escape": {
+		"category": "not_es3"
+	},
+	"annexB/built-ins/RegExp/RegExp-leading-escape-BMP": {
+		"category": "not_es3"
+	},
+	"annexB/built-ins/RegExp/RegExp-trailing-escape": {
+		"category": "not_es3"
+	},
+	"annexB/built-ins/RegExp/RegExp-trailing-escape-BMP": {
+		"category": "not_es3"
+	},
+	"annexB/built-ins/RegExp/prototype/compile/B.RegExp.prototype.compile": {
+		"category": "not_es3"
+	},
+	"annexB/built-ins/RegExp/prototype/compile/length": {
+		"category": "not_es3"
+	},
+	"annexB/built-ins/RegExp/prototype/compile/name": {
+		"category": "not_es3"
+	},
+	"annexB/built-ins/String/prototype/anchor/B.2.3.2": {
+		"category": "bad_test"
+	},
+	"annexB/built-ins/String/prototype/anchor/length": {
+		"category": "bad_test"
+	},
+	"annexB/built-ins/String/prototype/anchor/name": {
+		"category": "bad_test"
+	},
+	"annexB/built-ins/String/prototype/big/B.2.3.3": {
+		"category": "bad_test"
+	},
+	"annexB/built-ins/String/prototype/big/length": {
+		"category": "bad_test"
+	},
+	"annexB/built-ins/String/prototype/big/name": {
+		"category": "bad_test"
+	},
+	"annexB/built-ins/String/prototype/blink/B.2.3.4": {
+		"category": "bad_test"
+	},
+	"annexB/built-ins/String/prototype/blink/length": {
+		"category": "bad_test"
+	},
+	"annexB/built-ins/String/prototype/blink/name": {
+		"category": "bad_test"
+	},
+	"annexB/built-ins/String/prototype/bold/B.2.3.5": {
+		"category": "bad_test"
+	},
+	"annexB/built-ins/String/prototype/bold/length": {
+		"category": "bad_test"
+	},
+	"annexB/built-ins/String/prototype/bold/name": {
+		"category": "bad_test"
+	},
+	"annexB/built-ins/String/prototype/fixed/B.2.3.6": {
+		"category": "bad_test"
+	},
+	"annexB/built-ins/String/prototype/fixed/length": {
+		"category": "bad_test"
+	},
+	"annexB/built-ins/String/prototype/fixed/name": {
+		"category": "bad_test"
+	},
+	"annexB/built-ins/String/prototype/fontcolor/B.2.3.7": {
+		"category": "bad_test"
+	},
+	"annexB/built-ins/String/prototype/fontcolor/length": {
+		"category": "bad_test"
+	},
+	"annexB/built-ins/String/prototype/fontcolor/name": {
+		"category": "bad_test"
+	},
+	"annexB/built-ins/String/prototype/fontsize/B.2.3.8": {
+		"category": "bad_test"
+	},
+	"annexB/built-ins/String/prototype/fontsize/length": {
+		"category": "bad_test"
+	},
+	"annexB/built-ins/String/prototype/fontsize/name": {
+		"category": "bad_test"
+	},
+	"annexB/built-ins/String/prototype/italics/B.2.3.9": {
+		"category": "bad_test"
+	},
+	"annexB/built-ins/String/prototype/italics/length": {
+		"category": "bad_test"
+	},
+	"annexB/built-ins/String/prototype/italics/name": {
+		"category": "bad_test"
+	},
+	"annexB/built-ins/String/prototype/link/B.2.3.10": {
+		"category": "bad_test"
+	},
+	"annexB/built-ins/String/prototype/link/length": {
+		"category": "bad_test"
+	},
+	"annexB/built-ins/String/prototype/link/name": {
+		"category": "bad_test"
+	},
+	"annexB/built-ins/String/prototype/small/B.2.3.11": {
+		"category": "bad_test"
+	},
+	"annexB/built-ins/String/prototype/small/length": {
+		"category": "bad_test"
+	},
+	"annexB/built-ins/String/prototype/small/name": {
+		"category": "bad_test"
+	},
+	"annexB/built-ins/String/prototype/strike/B.2.3.12": {
+		"category": "bad_test"
+	},
+	"annexB/built-ins/String/prototype/strike/length": {
+		"category": "bad_test"
+	},
+	"annexB/built-ins/String/prototype/strike/name": {
+		"category": "bad_test"
+	},
+	"annexB/built-ins/String/prototype/sub/B.2.3.13": {
+		"category": "bad_test"
+	},
+	"annexB/built-ins/String/prototype/sub/length": {
+		"category": "bad_test"
+	},
+	"annexB/built-ins/String/prototype/sub/name": {
+		"category": "bad_test"
+	},
+	"annexB/built-ins/String/prototype/substr/B.2.3": {
+		"category": "not_es3"
+	},
+	"annexB/built-ins/String/prototype/substr/length": {
+		"category": "not_es3"
+	},
+	"annexB/built-ins/String/prototype/substr/name": {
+		"category": "not_es3"
+	},
+	"annexB/built-ins/String/prototype/sup/B.2.3.14": {
+		"category": "bad_test"
+	},
+	"annexB/built-ins/String/prototype/sup/length": {
+		"category": "bad_test"
+	},
+	"annexB/built-ins/String/prototype/sup/name": {
+		"category": "bad_test"
+	},
+	"annexB/built-ins/escape/B.2.1": {
+		"category": "not_es3"
+	},
+	"annexB/built-ins/escape/B.2.1.propertyCheck": {
+		"category": "not_es3"
+	},
+	"annexB/built-ins/escape/length": {
+		"category": "not_es3"
+	},
+	"annexB/built-ins/escape/name": {
+		"category": "not_es3"
+	},
+	"annexB/built-ins/unescape/B.2.2": {
+		"category": "not_es3"
+	},
+	"annexB/built-ins/unescape/B.2.2.propertyCheck": {
+		"category": "not_es3"
+	},
+	"annexB/built-ins/unescape/length": {
+		"category": "not_es3"
+	},
+	"annexB/built-ins/unescape/name": {
+		"category": "not_es3"
+	},
 	"annexB/language/expressions/object/__proto__": {
 		"category": "not_es3"
 	},
 	"annexB/language/expressions/template-literal/legacy-octal-escape-sequence-non-strict": {
 		"category": "not_es3"
 	},
-	"annexB/language/statements/try/catch-redeclared-var-statement-captured": {
-		"category": ""
-	},
-	"language/comments/S7.4_A5": {
-		"category": ""
-	},
-	"language/computed-property-names/basics/number": {
-		"category": "not_es3"
-	},
-	"language/computed-property-names/basics/string": {
-		"category": "not_es3"
-	},
-	"language/computed-property-names/basics/symbol": {
-		"category": "not_es3"
-	},
-	"language/computed-property-names/class/accessor/getter-duplicates": {
-		"category": "not_es3"
-	},
-	"language/computed-property-names/class/accessor/getter": {
-		"category": "not_es3"
-	},
-	"language/computed-property-names/class/accessor/setter-duplicates": {
-		"category": "not_es3"
-	},
-	"language/arguments-object/10.6-11-b-1": {
-		"category": "not_es3"
-	},
-	"language/expressions/array/11.1.4-0": {
-		"category": ""
-	},
-	"language/expressions/array/S11.1.4_A1.7": {
-		"category": ""
-	},
-	"language/expressions/array/S11.1.4_A1.6": {
-		"category": ""
-	},
-	"language/expressions/array/S11.1.4_A1.5": {
-		"category": ""
-	},
-	"language/expressions/array/S11.1.4_A1.4": {
-		"category": ""
-	},
-	"language/expressions/array/S11.1.4_A1.2": {
-		"category": ""
-	},
-	"language/expressions/addition/S11.6.1_A1": {
-		"category": ""
-	},
-	"language/expressions/compound-assignment/S11.13.2_A7.10_T2": {
-		"category": "tbd"
-	},
-	"language/expressions/conditional/S11.12_A1": {
-		"category": ""
-	},
-	"language/literals/numeric/S7.8.3_A5.1_T2": {
-		"category": ""
-	},
-	"language/literals/numeric/S7.8.3_A5.1_T4": {
-		"category": ""
-	},
-	"language/literals/numeric/S7.8.3_A5.1_T6": {
-		"category": ""
-	},
-	"language/literals/numeric/S7.8.3_A5.1_T8": {
-		"category": ""
-	},
-	"language/literals/numeric/binary": {
-		"category": "not_es3"
-	},
-	"language/literals/numeric/octal": {
-		"category": "not_es3"
-	},
-	"language/literals/string/7.8.4-1-s": {
-		"category": "tbd"
-	},
-	"language/arguments-object/10.6-12-2": {
-		"category": "not_es3"
-	},
-	"language/arguments-object/10.6-13-a-1": {
-		"category": ""
-	},
-	"language/arguments-object/10.6-13-a-2": {
-		"category": ""
-	},
-	"language/arguments-object/10.6-13-a-3": {
-		"category": ""
-	},
-	"language/arguments-object/10.6-13-c-2-s": {
-		"category": "tbd"
-	},
-	"language/arguments-object/mapped/Symbol.iterator": {
-		"category": "not_es3"
-	},
-	"language/block-scope/leave/finally-block-let-declaration-only-shadows-outer-parameter-value-1": {
-		"category": "not_es3"
-	},
-	"language/block-scope/leave/finally-block-let-declaration-only-shadows-outer-parameter-value-2": {
-		"category": "not_es3"
-	},
-	"language/block-scope/leave/for-loop-block-let-declaration-only-shadows-outer-parameter-value-1": {
-		"category": "not_es3"
-	},
-	"language/block-scope/leave/for-loop-block-let-declaration-only-shadows-outer-parameter-value-2": {
-		"category": "not_es3"
-	},
-	"language/block-scope/leave/nested-block-let-declaration-only-shadows-outer-parameter-value-1": {
-		"category": "not_es3"
-	},
-	"language/block-scope/leave/nested-block-let-declaration-only-shadows-outer-parameter-value-2": {
-		"category": "not_es3"
-	},
-	"language/block-scope/leave/outermost-binding-updated-in-catch-block-nested-block-let-declaration-unseen-outside-of-block": {
-		"category": "not_es3"
-	},
-	"language/block-scope/leave/try-block-let-declaration-only-shadows-outer-parameter-value-1": {
-		"category": "not_es3"
-	},
-	"language/block-scope/leave/try-block-let-declaration-only-shadows-outer-parameter-value-2": {
-		"category": "not_es3"
-	},
-	"language/block-scope/leave/verify-context-in-finally-block": {
-		"category": "not_es3"
-	},
-	"language/block-scope/leave/verify-context-in-for-loop-block": {
-		"category": "not_es3"
-	},
-	"language/block-scope/leave/verify-context-in-labelled-block": {
-		"category": "not_es3"
-	},
-	"language/block-scope/leave/verify-context-in-try-block": {
-		"category": "not_es3"
-	},
-	"language/block-scope/leave/x-after-break-to-label": {
-		"category": "not_es3"
-	},
-	"language/block-scope/leave/x-before-continue": {
-		"category": "not_es3"
-	},
-	"language/block-scope/return-from/block-const": {
-		"category": "not_es3"
-	},
-	"language/block-scope/return-from/block-let": {
-		"category": "not_es3"
-	},
-	"language/block-scope/shadowing/catch-parameter-shadowing-let-declaration": {
-		"category": "not_es3"
-	},
-	"language/block-scope/shadowing/const-declaration-shadowing-catch-parameter": {
-		"category": "not_es3"
-	},
-	"language/block-scope/shadowing/const-declarations-shadowing-parameter-name-let-const-and-var-variables": {
-		"category": "not_es3"
-	},
-	"language/block-scope/shadowing/dynamic-lookup-from-closure": {
-		"category": "not_es3"
-	},
-	"language/block-scope/shadowing/dynamic-lookup-in-and-through-block-contexts": {
-		"category": "not_es3"
-	},
-	"language/block-scope/shadowing/let-declaration-shadowing-catch-parameter": {
-		"category": "not_es3"
-	},
-	"language/block-scope/shadowing/let-declarations-shadowing-parameter-name-let-const-and-var": {
-		"category": "not_es3"
-	},
-	"language/block-scope/shadowing/lookup-from-closure": {
-		"category": "not_es3"
-	},
-	"language/block-scope/shadowing/lookup-in-and-through-block-contexts": {
-		"category": "not_es3"
-	},
-	"language/block-scope/shadowing/parameter-name-shadowing-parameter-name-let-const-and-var": {
-		"category": "not_es3"
-	},
-	"language/block-scope/syntax/for-in/acquire-properties-from-array": {
-		"category": "not_es3"
-	},
-	"language/block-scope/syntax/for-in/acquire-properties-from-object": {
-		"category": "not_es3"
-	},
-	"language/block-scope/syntax/for-in/mixed-values-in-iteration": {
-		"category": "not_es3"
-	},
-	"language/block-scope/syntax/redeclaration-in-block/attempt-to-redeclare-function-declaration-with-function-declaration": {
-		"category": "tbd"
-	},
-	"language/block-scope/syntax/redeclaration-in-block/attempt-to-redeclare-function-declaration-with-var": {
-		"category": "tbd"
-	},
-	"language/block-scope/syntax/redeclaration-in-block/attempt-to-redeclare-var-with-function-declaration": {
-		"category": "tbd"
-	},
-	"language/computed-property-names/class/accessor/setter": {
-		"category": "not_es3"
-	},
-	"language/computed-property-names/class/method/constructor-can-be-generator": {
-		"category": "not_es3"
-	},
-	"language/computed-property-names/class/method/constructor-can-be-getter": {
-		"category": "not_es3"
-	},
-	"language/computed-property-names/class/method/constructor-can-be-setter": {
-		"category": "not_es3"
-	},
-	"language/computed-property-names/class/method/constructor-duplicate-1": {
-		"category": "not_es3"
-	},
-	"language/computed-property-names/class/method/constructor-duplicate-2": {
-		"category": "not_es3"
-	},
-	"language/computed-property-names/class/method/constructor-duplicate-3": {
-		"category": "not_es3"
-	},
-	"language/computed-property-names/class/method/constructor": {
-		"category": "not_es3"
-	},
-	"language/computed-property-names/class/method/generator": {
-		"category": "not_es3"
-	},
-	"language/computed-property-names/class/method/number": {
-		"category": "not_es3"
-	},
-	"language/computed-property-names/class/method/string": {
-		"category": "not_es3"
-	},
-	"language/computed-property-names/class/method/symbol": {
-		"category": "not_es3"
-	},
-	"language/computed-property-names/class/static/generator-constructor": {
-		"category": "not_es3"
-	},
-	"language/computed-property-names/class/static/generator-prototype": {
-		"category": "not_es3"
-	},
-	"language/computed-property-names/class/static/getter-constructor": {
-		"category": "not_es3"
-	},
-	"language/computed-property-names/class/static/getter-prototype": {
-		"category": "not_es3"
-	},
-	"language/computed-property-names/class/static/method-constructor": {
-		"category": "not_es3"
-	},
-	"language/computed-property-names/class/static/method-number": {
-		"category": "not_es3"
-	},
-	"language/computed-property-names/class/static/method-prototype": {
-		"category": "not_es3"
-	},
-	"language/computed-property-names/class/static/method-string": {
-		"category": "not_es3"
-	},
-	"language/computed-property-names/class/static/method-symbol": {
-		"category": "not_es3"
-	},
-	"language/computed-property-names/class/static/setter-constructor": {
-		"category": "not_es3"
-	},
-	"language/computed-property-names/class/static/setter-prototype": {
-		"category": "not_es3"
-	},
-	"language/computed-property-names/object/accessor/getter-duplicates": {
-		"category": "not_es3"
-	},
-	"language/computed-property-names/object/accessor/getter-super": {
-		"category": "not_es3"
-	},
-	"language/computed-property-names/object/accessor/getter": {
-		"category": "not_es3"
-	},
-	"language/computed-property-names/object/accessor/setter-duplicates": {
-		"category": "not_es3"
-	},
-	"language/computed-property-names/object/accessor/setter-super": {
-		"category": "not_es3"
-	},
-	"language/computed-property-names/object/accessor/setter": {
-		"category": "not_es3"
-	},
-	"language/computed-property-names/object/method/generator": {
-		"category": "not_es3"
-	},
-	"language/computed-property-names/object/method/number": {
-		"category": "not_es3"
-	},
-	"language/computed-property-names/object/method/string": {
-		"category": "not_es3"
-	},
-	"language/computed-property-names/object/method/super": {
-		"category": "not_es3"
-	},
-	"language/computed-property-names/object/method/symbol": {
-		"category": "not_es3"
-	},
-	"language/computed-property-names/object/property/number-duplicates": {
-		"category": "not_es3"
-	},
-	"language/computed-property-names/to-name-side-effects/class": {
-		"category": "not_es3"
-	},
-	"language/computed-property-names/to-name-side-effects/numbers-class": {
-		"category": "not_es3"
-	},
-	"language/computed-property-names/to-name-side-effects/numbers-object": {
-		"category": "not_es3"
-	},
-	"language/computed-property-names/to-name-side-effects/object": {
-		"category": "not_es3"
-	},
-	"language/default-parameters/call-define-values": {
-		"category": "not_es3"
-	},
-	"language/default-parameters/call-returns-reference-error": {
-		"category": "not_es3"
-	},
-	"language/default-parameters/class-definitions": {
-		"category": "not_es3"
-	},
-	"language/default-parameters/default-parameters-always-provide-unmapped-arguments": {
-		"category": "not_es3"
-	},
-	"language/default-parameters/destructuring": {
-		"category": "not_es3"
-	},
-	"language/default-parameters/function-constructor": {
-		"category": "not_es3"
-	},
-	"language/default-parameters/function-length": {
-		"category": "not_es3"
-	},
-	"language/default-parameters/generators": {
-		"category": "not_es3"
-	},
-	"language/default-parameters/method-definitions": {
-		"category": "not_es3"
-	},
-	"language/default-parameters/param-ref-initialized": {
-		"category": "not_es3"
-	},
-	"language/default-parameters/param-ref-uninitialized": {
-		"category": "not_es3"
-	},
-	"language/default-parameters/replace-default-values": {
-		"category": "not_es3"
-	},
-	"language/default-parameters/returns-abrupt-from-property-value": {
-		"category": "not_es3"
-	},
-	"language/default-parameters/scope": {
-		"category": "not_es3"
-	},
-	"language/default-parameters/variable-initial-value-as-parameter": {
-		"category": "not_es3"
-	},
-	"language/default-parameters/variable-initial-value-undefined": {
-		"category": "not_es3"
-	},
-	"language/destructuring/binding/initialization-requires-object-coercible-null": {
-		"category": "not_es3"
-	},
-	"language/destructuring/binding/initialization-requires-object-coercible-undefined": {
-		"category": "not_es3"
-	},
-	"language/destructuring/binding/initialization-returns-normal-completion-for-empty-objects": {
-		"category": "not_es3"
-	},
-	"language/destructuring/binding/syntax/array-elements-with-initializer": {
-		"category": "not_es3"
-	},
-	"language/destructuring/binding/syntax/array-elements-with-object-patterns": {
-		"category": "not_es3"
-	},
-	"language/destructuring/binding/syntax/array-elements-without-initializer": {
-		"category": "not_es3"
-	},
-	"language/destructuring/binding/syntax/array-pattern-with-elisions": {
-		"category": "not_es3"
-	},
-	"language/destructuring/binding/syntax/array-pattern-with-no-elements": {
-		"category": "not_es3"
-	},
-	"language/destructuring/binding/syntax/array-rest-elements": {
-		"category": "not_es3"
-	},
-	"language/destructuring/binding/syntax/object-pattern-with-no-property-list": {
-		"category": "not_es3"
-	},
-	"language/destructuring/binding/syntax/property-list-bindings-elements": {
-		"category": "not_es3"
-	},
-	"language/destructuring/binding/syntax/property-list-followed-by-a-single-comma": {
-		"category": "not_es3"
-	},
-	"language/destructuring/binding/syntax/property-list-single-name-bindings": {
-		"category": "not_es3"
-	},
-	"language/destructuring/binding/syntax/property-list-with-property-list": {
-		"category": "not_es3"
-	},
-	"language/destructuring/binding/syntax/recursive-array-and-object-patterns": {
-		"category": "not_es3"
-	},
-	"language/directive-prologue/10.1.1-11-s": {
-		"category": "not_es3"
-	},
-	"language/eval-code/10.4.2-1-5": {
-		"category": "not_es3"
-	},
-	"language/expressions/arrow-function/ArrowFunction_restricted-properties": {
-		"category": "not_es3"
-	},
-	"language/expressions/arrow-function/arrow/binding-tests-1": {
-		"category": "not_es3"
-	},
-	"language/expressions/arrow-function/arrow/binding-tests-2": {
-		"category": "not_es3"
-	},
-	"language/expressions/arrow-function/arrow/binding-tests-3": {
-		"category": "not_es3"
-	},
-	"language/expressions/arrow-function/arrow/capturing-closure-variables-1": {
-		"category": "not_es3"
-	},
-	"language/expressions/arrow-function/arrow/capturing-closure-variables-2": {
-		"category": "not_es3"
-	},
-	"language/expressions/arrow-function/arrow/concisebody-lookahead-assignmentexpression-1": {
-		"category": "not_es3"
-	},
-	"language/expressions/arrow-function/arrow/concisebody-lookahead-assignmentexpression-2": {
-		"category": "not_es3"
-	},
-	"language/expressions/arrow-function/cannot-override-this-with-thisArg": {
-		"category": "not_es3"
-	},
-	"language/expressions/arrow-function/empty-function-body-returns-undefined": {
-		"category": "not_es3"
-	},
-	"language/expressions/arrow-function/expression-body-implicit-return": {
-		"category": "not_es3"
-	},
-	"language/expressions/arrow-function/lexical-arguments": {
-		"category": "not_es3"
-	},
-	"language/expressions/arrow-function/lexical-bindings-overriden-by-formal-parameters-non-strict": {
-		"category": "not_es3"
-	},
-	"language/expressions/arrow-function/lexical-new.target": {
-		"category": "not_es3"
-	},
-	"language/expressions/arrow-function/lexical-new.target-closure-returned": {
-		"category": "not_es3"
-	},
-	"language/expressions/arrow-function/lexical-super-call-from-within-constructor": {
-		"category": "not_es3"
-	},
-	"language/expressions/arrow-function/lexical-super-property": {
-		"category": "not_es3"
-	},
-	"language/expressions/arrow-function/lexical-super-property-from-within-constructor": {
-		"category": "not_es3"
-	},
-	"language/expressions/arrow-function/lexical-supercall-from-immediately-invoked-arrow": {
-		"category": "not_es3"
-	},
-	"language/expressions/arrow-function/lexical-this": {
-		"category": "not_es3"
-	},
-	"language/expressions/arrow-function/low-precedence-expression-body-no-parens": {
-		"category": "not_es3"
-	},
-	"language/expressions/arrow-function/non-strict": {
-		"category": "not_es3"
-	},
-	"language/expressions/arrow-function/object-literal-return-requires-body-parens": {
-		"category": "not_es3"
-	},
-	"language/expressions/arrow-function/prototype-rules": {
-		"category": "not_es3"
-	},
-	"language/expressions/arrow-function/statement-body-requires-braces-must-return-explicitly": {
-		"category": "not_es3"
-	},
-	"language/expressions/arrow-function/statement-body-requires-braces-must-return-explicitly-missing": {
-		"category": "not_es3"
-	},
-	"language/expressions/arrow-function/syntax/arrowparameters-bindingidentifier-arguments": {
-		"category": "not_es3"
-	},
-	"language/expressions/arrow-function/syntax/arrowparameters-bindingidentifier-concisebody-assignmentexpression": {
-		"category": "not_es3"
-	},
-	"language/expressions/arrow-function/syntax/arrowparameters-bindingidentifier-concisebody-functionbody": {
-		"category": "not_es3"
-	},
-	"language/expressions/arrow-function/syntax/arrowparameters-bindingidentifier-eval": {
-		"category": "not_es3"
-	},
-	"language/expressions/arrow-function/syntax/arrowparameters-bindingidentifier-lineterminator-concisebody-assignmentexpression": {
-		"category": "not_es3"
-	},
-	"language/expressions/arrow-function/syntax/arrowparameters-bindingidentifier-lineterminator-concisebody-functionbody": {
-		"category": "not_es3"
-	},
-	"language/expressions/arrow-function/syntax/arrowparameters-bindingidentifier-yield": {
-		"category": "not_es3"
-	},
-	"language/expressions/arrow-function/syntax/arrowparameters-cover-concisebody-assignmentexpression": {
-		"category": "not_es3"
-	},
-	"language/expressions/arrow-function/syntax/arrowparameters-cover-concisebody-functionbody": {
-		"category": "not_es3"
-	},
-	"language/expressions/arrow-function/syntax/arrowparameters-cover-formalparameters-arguments": {
-		"category": "not_es3"
-	},
-	"language/expressions/arrow-function/syntax/arrowparameters-cover-formalparameters-eval": {
-		"category": "not_es3"
-	},
-	"language/expressions/arrow-function/syntax/arrowparameters-cover-formalparameters-yield": {
-		"category": "not_es3"
-	},
-	"language/expressions/arrow-function/syntax/arrowparameters-cover-includes-rest-concisebody-functionbody": {
-		"category": "not_es3"
-	},
-	"language/expressions/arrow-function/syntax/arrowparameters-cover-initialize-1": {
-		"category": "not_es3"
-	},
-	"language/expressions/arrow-function/syntax/arrowparameters-cover-initialize-2": {
-		"category": "not_es3"
-	},
-	"language/expressions/arrow-function/syntax/arrowparameters-cover-lineterminator-concisebody-assignmentexpression": {
-		"category": "not_es3"
-	},
-	"language/expressions/arrow-function/syntax/arrowparameters-cover-lineterminator-concisebody-functionbody": {
-		"category": "not_es3"
-	},
-	"language/expressions/arrow-function/syntax/arrowparameters-cover-rest-concisebody-functionbody": {
-		"category": "not_es3"
-	},
-	"language/expressions/arrow-function/syntax/arrowparameters-cover-rest-lineterminator-concisebody-functionbody": {
-		"category": "not_es3"
-	},
-	"language/expressions/arrow-function/syntax/variations": {
-		"category": "not_es3"
-	},
-	"language/expressions/arrow-function/throw-new": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/11.13.1-4-1": {
-		"category": "tbd"
-	},
-	"language/expressions/assignment/8.12.5-3-b_1": {
-		"category": "tbd"
-	},
-	"language/expressions/assignment/8.12.5-3-b_2": {
-		"category": "tbd"
-	},
-	"language/expressions/assignment/8.12.5-5-b_1": {
-		"category": "tbd"
-	},
-	"language/expressions/assignment/S11.13.1_A1": {
-		"category": ""
-	},
-	"language/expressions/assignment/S11.13.1_A5_T1": {
-		"category": "by_design"
-	},
-	"language/expressions/assignment/S11.13.1_A5_T2": {
-		"category": "by_design"
-	},
-	"language/expressions/assignment/S11.13.1_A5_T3": {
-		"category": "by_design"
-	},
-	"language/expressions/assignment/S11.13.1_A5_T4": {
-		"category": "by_design"
-	},
-	"language/expressions/assignment/S11.13.1_A6_T1": {
-		"category": "by_design"
-	},
-	"language/expressions/assignment/S11.13.1_A6_T2": {
-		"category": "by_design"
-	},
-	"language/expressions/assignment/S11.13.1_A6_T3": {
-		"category": "by_design"
-	},
-	"language/expressions/assignment/S11.13.1_A7_T1": {
-		"category": "by_design"
-	},
-	"language/expressions/assignment/S11.13.1_A7_T2": {
-		"category": "by_design"
-	},
-	"language/expressions/assignment/destructuring/array-elem-elision": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/array-elem-init-assignment": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/array-elem-init-evaluation": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/array-elem-init-fn-name-arrow": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/array-elem-init-fn-name-class": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/array-elem-init-fn-name-cover": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/array-elem-init-fn-name-fn": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/array-elem-init-fn-name-gen": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/array-elem-init-in": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/array-elem-init-let": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/array-elem-init-order": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/array-elem-init-simple-no-strict": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/array-elem-init-yield-expr": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/array-elem-init-yield-ident-valid": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/array-elem-nested-array": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/array-elem-nested-array-invalid": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/array-elem-nested-array-null": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/array-elem-nested-array-undefined": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/array-elem-nested-array-undefined-hole": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/array-elem-nested-array-undefined-own": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/array-elem-nested-array-yield-expr": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/array-elem-nested-array-yield-ident-valid": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/array-elem-nested-obj": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/array-elem-nested-obj-null": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/array-elem-nested-obj-undefined": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/array-elem-nested-obj-undefined-hole": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/array-elem-nested-obj-undefined-own": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/array-elem-nested-obj-yield-expr": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/array-elem-nested-obj-yield-ident-valid": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/array-elem-put-const": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/array-elem-put-let": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/array-elem-put-prop-ref": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/array-elem-put-prop-ref-no-get": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/array-elem-put-prop-ref-user-err": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/array-elem-put-unresolvable-no-strict": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/array-elem-target-identifier": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/array-elem-target-simple-no-strict": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/array-elem-target-yield-expr": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/array-elem-target-yield-valid": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/array-empty": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/array-iteration": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/array-rest-after-element": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/array-rest-after-elision": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/array-rest-elision": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/array-rest-iteration": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/array-rest-nested-array": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/array-rest-nested-array-null": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/array-rest-nested-array-undefined": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/array-rest-nested-array-undefined-hole": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/array-rest-nested-array-undefined-own": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/array-rest-nested-array-yield-expr": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/array-rest-nested-array-yield-ident-valid": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/array-rest-nested-obj": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/array-rest-nested-obj-null": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/array-rest-nested-obj-undefined": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/array-rest-nested-obj-undefined-hole": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/array-rest-nested-obj-undefined-own": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/array-rest-nested-obj-yield-expr": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/array-rest-nested-obj-yield-ident-valid": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/array-rest-put-const": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/array-rest-put-let": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/array-rest-put-prop-ref": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/array-rest-put-prop-ref-no-get": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/array-rest-put-prop-ref-user-err": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/array-rest-put-unresolvable-no-strict": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/array-rest-yield-expr": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/array-rest-yield-ident-valid": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/array-sparse": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/obj-id-identifier-resolution": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/obj-id-identifier-yield-ident-valid": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/obj-id-init-assignment": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/obj-id-init-evaluation": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/obj-id-init-fn-name-arrow": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/obj-id-init-fn-name-class": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/obj-id-init-fn-name-cover": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/obj-id-init-fn-name-fn": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/obj-id-init-fn-name-gen": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/obj-id-init-in": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/obj-id-init-let": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/obj-id-init-order": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/obj-id-init-simple-no-strict": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/obj-id-init-yield-expr": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/obj-id-init-yield-ident-valid": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/obj-id-put-const": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/obj-id-put-let": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/obj-id-put-unresolvable-no-strict": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/obj-id-simple-no-strict": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/obj-prop-elem-init-assignment": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/obj-prop-elem-init-evaluation": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/obj-prop-elem-init-fn-name-arrow": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/obj-prop-elem-init-fn-name-class": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/obj-prop-elem-init-fn-name-cover": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/obj-prop-elem-init-fn-name-fn": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/obj-prop-elem-init-fn-name-gen": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/obj-prop-elem-init-in": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/obj-prop-elem-init-let": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/obj-prop-elem-init-yield-expr": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/obj-prop-elem-init-yield-ident-valid": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/obj-prop-elem-target-yield-expr": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/obj-prop-elem-target-yield-ident-valid": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/obj-prop-identifier-resolution": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/obj-prop-name-evaluation": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/obj-prop-name-evaluation-error": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/obj-prop-nested-array": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/obj-prop-nested-array-invalid": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/obj-prop-nested-array-null": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/obj-prop-nested-array-undefined": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/obj-prop-nested-array-undefined-own": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/obj-prop-nested-array-yield-expr": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/obj-prop-nested-array-yield-ident-valid": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/obj-prop-nested-obj": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/obj-prop-nested-obj-null": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/obj-prop-nested-obj-undefined": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/obj-prop-nested-obj-undefined-own": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/obj-prop-nested-obj-yield-expr": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/obj-prop-nested-obj-yield-ident-valid": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/obj-prop-put-const": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/obj-prop-put-let": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/obj-prop-put-order": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/obj-prop-put-prop-ref": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/obj-prop-put-prop-ref-no-get": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/obj-prop-put-prop-ref-user-err": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/obj-prop-put-unresolvable-no-strict": {
-		"category": "not_es3"
-	},
-	"language/statements/for-in/head-expr-expr": {
-		"category": ""
-	},
-	"language/statements/for-in/head-lhs-cover": {
-		"category": ""
-	},
-	"language/statements/for-in/head-lhs-invalid-asnmt-ptrn-obj": {
-		"category": ""
-	},
-	"language/statements/for-in/head-lhs-member": {
-		"category": ""
-	},
-	"language/statements/for-in/head-var-bound-names-in-stmt": {
-		"category": ""
-	},
-	"language/statements/for-in/head-var-expr": {
-		"category": ""
-	},
-	"language/statements/for-in/S12.6.4_A1": {
-		"category": "not_es3"
-	},
-	"language/statements/for-in/S12.6.4_A14_T2": {
-		"category": ""
-	},
-	"language/statements/for-in/S12.6.4_A15": {
-		"category": ""
-	},
-	"language/statements/for-in/S12.6.4_A2": {
-		"category": "not_es3"
-	},
-	"language/arguments-object/10.6-14-c-1-s": {
-		"category": ""
-	},
-	"language/arguments-object/10.6-5-1": {
-		"category": ""
-	},
-	"language/arguments-object/10.6-6-1": {
-		"category": "tbd"
-	},
-	"language/arguments-object/10.6-6-2": {
-		"category": "tbd"
-	},
-	"language/arguments-object/10.6-7-1": {
-		"category": ""
-	},
-	"language/arguments-object/S10.6_A2": {
-		"category": ""
-	},
-	"language/arguments-object/S10.6_A3_T1": {
-		"category": ""
-	},
-	"language/arguments-object/S10.6_A4": {
-		"category": ""
-	},
-	"language/arguments-object/S10.6_A5_T1": {
-		"category": ""
-	},
-	"language/arguments-object/mapped/mapped-arguments-nonconfigurable-1": {
-		"category": "tbd"
-	},
-	"language/arguments-object/mapped/mapped-arguments-nonconfigurable-2": {
-		"category": "tbd"
-	},
-	"language/arguments-object/mapped/mapped-arguments-nonconfigurable-3": {
-		"category": "tbd"
-	},
-	"language/arguments-object/mapped/mapped-arguments-nonconfigurable-4": {
-		"category": "tbd"
-	},
-	"language/arguments-object/mapped/mapped-arguments-nonconfigurable-delete-1": {
-		"category": "tbd"
-	},
-	"language/arguments-object/mapped/mapped-arguments-nonconfigurable-delete-2": {
-		"category": "tbd"
-	},
-	"language/arguments-object/mapped/mapped-arguments-nonconfigurable-delete-3": {
-		"category": "tbd"
-	},
-	"language/arguments-object/mapped/mapped-arguments-nonconfigurable-delete-4": {
-		"category": "tbd"
-	},
-	"language/arguments-object/mapped/mapped-arguments-nonconfigurable-nonwritable-1": {
-		"category": "tbd"
-	},
-	"language/arguments-object/mapped/mapped-arguments-nonconfigurable-nonwritable-2": {
-		"category": "tbd"
-	},
-	"language/arguments-object/mapped/mapped-arguments-nonconfigurable-nonwritable-3": {
-		"category": "tbd"
-	},
-	"language/arguments-object/mapped/mapped-arguments-nonconfigurable-nonwritable-4": {
-		"category": "tbd"
-	},
-	"language/arguments-object/mapped/mapped-arguments-nonconfigurable-nonwritable-5": {
-		"category": "tbd"
-	},
-	"language/arguments-object/mapped/mapped-arguments-nonconfigurable-strict-delete-1": {
-		"category": "tbd"
-	},
-	"language/arguments-object/mapped/mapped-arguments-nonconfigurable-strict-delete-2": {
-		"category": "tbd"
-	},
-	"language/arguments-object/mapped/mapped-arguments-nonconfigurable-strict-delete-3": {
-		"category": "tbd"
-	},
-	"language/arguments-object/mapped/mapped-arguments-nonconfigurable-strict-delete-4": {
-		"category": "tbd"
-	},
-	"language/arguments-object/mapped/mapped-arguments-nonwritable-nonconfigurable-1": {
-		"category": "tbd"
-	},
-	"language/arguments-object/mapped/mapped-arguments-nonwritable-nonconfigurable-2": {
-		"category": "tbd"
-	},
-	"language/arguments-object/mapped/mapped-arguments-nonwritable-nonconfigurable-3": {
-		"category": "tbd"
-	},
-	"language/arguments-object/mapped/mapped-arguments-nonwritable-nonconfigurable-4": {
-		"category": "tbd"
-	},
-	"language/arguments-object/unmapped/Symbol.iterator": {
-		"category": "not_es3"
-	},
-	"language/directive-prologue/10.1.1-14-s": {
-		"category": "not_es3"
-	},
-	"language/directive-prologue/10.1.1-15-s": {
-		"category": "not_es3"
-	},
-	"language/directive-prologue/10.1.1-16-s": {
-		"category": "not_es3"
-	},
-	"language/directive-prologue/10.1.1-17-s": {
-		"category": "not_es3"
-	},
-	"language/directive-prologue/10.1.1-18-s": {
-		"category": "not_es3"
-	},
-	"language/directive-prologue/10.1.1-19-s": {
-		"category": "not_es3"
-	},
-	"language/directive-prologue/10.1.1-2-s": {
-		"category": "not_es3"
-	},
-	"language/directive-prologue/10.1.1-22-s": {
-		"category": "not_es3"
-	},
-	"language/directive-prologue/10.1.1-25-s": {
-		"category": "not_es3"
-	},
-	"language/directive-prologue/10.1.1-26-s": {
-		"category": "not_es3"
-	},
-	"language/directive-prologue/10.1.1-27-s": {
-		"category": "not_es3"
-	},
-	"language/directive-prologue/10.1.1-28-s": {
-		"category": "not_es3"
-	},
-	"language/directive-prologue/10.1.1-2gs": {
-		"category": "not_es3"
-	},
-	"language/directive-prologue/10.1.1-30-s": {
-		"category": "not_es3"
-	},
-	"language/directive-prologue/10.1.1-5-s": {
-		"category": "not_es3"
-	},
-	"language/directive-prologue/10.1.1-5gs": {
-		"category": "not_es3"
-	},
-	"language/directive-prologue/10.1.1-8-s": {
-		"category": "not_es3"
-	},
-	"language/directive-prologue/10.1.1-8gs": {
-		"category": "not_es3"
-	},
-	"language/directive-prologue/14.1-1-s": {
-		"category": "not_es3"
-	},
-	"language/directive-prologue/14.1-10-s": {
-		"category": "not_es3"
-	},
-	"language/directive-prologue/14.1-11-s": {
-		"category": "not_es3"
-	},
-	"language/directive-prologue/14.1-12-s": {
-		"category": "not_es3"
-	},
-	"language/directive-prologue/14.1-13-s": {
-		"category": "not_es3"
-	},
-	"language/directive-prologue/14.1-14-s": {
-		"category": "not_es3"
-	},
-	"language/directive-prologue/14.1-15-s": {
-		"category": "not_es3"
-	},
-	"language/directive-prologue/14.1-2-s": {
-		"category": "not_es3"
-	},
-	"language/directive-prologue/14.1-4-s": {
-		"category": "not_es3"
-	},
-	"language/directive-prologue/14.1-4gs": {
-		"category": "not_es3"
-	},
-	"language/directive-prologue/14.1-5gs": {
-		"category": "not_es3"
-	},
-	"language/directive-prologue/14.1-8-s": {
-		"category": "not_es3"
-	},
-	"language/directive-prologue/14.1-9-s": {
-		"category": "not_es3"
-	},
-	"language/eval-code/10.4.2-3-c-1-s": {
-		"category": "not_es3"
-	},
-	"language/eval-code/10.4.2.1-4-s": {
-		"category": "not_es3"
-	},
-	"language/eval-code/S10.4.2.1_A1": {
-		"category": "not_es3"
-	},
-	"language/eval-code/non-definable-function-with-function": {
-		"category": "tbd"
-	},
-	"language/eval-code/non-definable-function-with-variable": {
-		"category": "tbd"
-	},
-	"language/eval-code/non-definable-global-function": {
-		"category": "tbd"
-	},
-	"language/eval-code/non-definable-global-generator": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/fn-name-arrow": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/fn-name-class": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/fn-name-cover": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/fn-name-fn": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/fn-name-gen": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/fn-name-lhs-cover": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/fn-name-lhs-member": {
-		"category": "not_es3"
-	},
-	"language/expressions/assignment/destructuring/object-empty": {
-		"category": "not_es3"
-	},
-	"language/expressions/bitwise-and/S11.10.1_A1": {
-		"category": ""
-	},
-	"language/expressions/bitwise-not/S11.4.8_A1": {
-		"category": ""
-	},
-	"language/expressions/bitwise-or/S11.10.3_A1": {
-		"category": ""
-	},
-	"language/expressions/bitwise-xor/S11.10.2_A1": {
-		"category": ""
-	},
-	"language/expressions/call/11.2.3-3_3": {
-		"category": "tbd"
-	},
-	"language/expressions/call/11.2.3-3_4": {
-		"category": "tbd"
-	},
-	"language/expressions/call/11.2.3-3_6": {
-		"category": "tbd"
-	},
-	"language/expressions/call/11.2.3-3_7": {
-		"category": "not_es3"
-	},
-	"language/expressions/call/S11.2.3_A1": {
-		"category": ""
-	},
-	"language/expressions/class/name": {
-		"category": "not_es3"
-	},
-	"language/expressions/class/restricted-properties": {
-		"category": "not_es3"
-	},
-	"language/expressions/comma/S11.14_A1": {
-		"category": ""
-	},
-	"language/expressions/compound-assignment/S11.13.2_A1_T1": {
-		"category": ""
-	},
-	"language/expressions/compound-assignment/S11.13.2_A1_T10": {
-		"category": ""
-	},
-	"language/expressions/compound-assignment/S11.13.2_A1_T11": {
-		"category": ""
-	},
-	"language/expressions/compound-assignment/S11.13.2_A1_T2": {
-		"category": ""
-	},
-	"language/expressions/compound-assignment/S11.13.2_A1_T3": {
-		"category": ""
-	},
-	"language/expressions/compound-assignment/S11.13.2_A1_T4": {
-		"category": ""
-	},
-	"language/expressions/compound-assignment/S11.13.2_A1_T5": {
-		"category": ""
-	},
-	"language/expressions/compound-assignment/S11.13.2_A1_T6": {
-		"category": ""
-	},
-	"language/expressions/compound-assignment/S11.13.2_A1_T7": {
-		"category": ""
-	},
-	"language/expressions/compound-assignment/S11.13.2_A1_T8": {
-		"category": ""
-	},
-	"language/expressions/compound-assignment/S11.13.2_A1_T9": {
-		"category": ""
-	},
-	"language/expressions/compound-assignment/S11.13.2_A5.10_T1": {
-		"category": "not_es3"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A5.10_T2": {
-		"category": "not_es3"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A5.10_T3": {
-		"category": "not_es3"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A5.10_T4": {
-		"category": "not_es3"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A5.10_T5": {
-		"category": "not_es3"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A5.11_T1": {
-		"category": "not_es3"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A5.11_T2": {
-		"category": "not_es3"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A5.11_T3": {
-		"category": "not_es3"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A5.11_T4": {
-		"category": "not_es3"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A5.11_T5": {
-		"category": "not_es3"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A5.1_T1": {
-		"category": "not_es3"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A5.1_T2": {
-		"category": "not_es3"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A5.1_T3": {
-		"category": "not_es3"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A5.1_T4": {
-		"category": "not_es3"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A5.1_T5": {
-		"category": "not_es3"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A5.2_T1": {
-		"category": "not_es3"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A5.2_T2": {
-		"category": "not_es3"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A5.2_T3": {
-		"category": "not_es3"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A5.2_T4": {
-		"category": "not_es3"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A5.2_T5": {
-		"category": "not_es3"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A5.3_T1": {
-		"category": "not_es3"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A5.3_T2": {
-		"category": "not_es3"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A5.3_T3": {
-		"category": "not_es3"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A5.3_T4": {
-		"category": "not_es3"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A5.3_T5": {
-		"category": "not_es3"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A5.4_T1": {
-		"category": "not_es3"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A5.4_T2": {
-		"category": "not_es3"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A5.4_T3": {
-		"category": "not_es3"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A5.4_T4": {
-		"category": "not_es3"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A5.4_T5": {
-		"category": "not_es3"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A5.5_T1": {
-		"category": "not_es3"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A5.5_T2": {
-		"category": "not_es3"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A5.5_T3": {
-		"category": "not_es3"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A5.5_T4": {
-		"category": "not_es3"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A5.5_T5": {
-		"category": "not_es3"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A5.6_T1": {
-		"category": "not_es3"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A5.6_T2": {
-		"category": "not_es3"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A5.6_T3": {
-		"category": "not_es3"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A5.6_T4": {
-		"category": "not_es3"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A5.6_T5": {
-		"category": "not_es3"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A5.7_T1": {
-		"category": "not_es3"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A5.7_T2": {
-		"category": "not_es3"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A5.7_T3": {
-		"category": "not_es3"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A5.7_T4": {
-		"category": "not_es3"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A5.7_T5": {
-		"category": "not_es3"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A5.8_T1": {
-		"category": "not_es3"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A5.8_T2": {
-		"category": "not_es3"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A5.8_T3": {
-		"category": "not_es3"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A5.8_T4": {
-		"category": "not_es3"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A5.8_T5": {
-		"category": "not_es3"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A5.9_T1": {
-		"category": "not_es3"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A5.9_T2": {
-		"category": "not_es3"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A5.9_T3": {
-		"category": "not_es3"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A5.9_T4": {
-		"category": "not_es3"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A5.9_T5": {
-		"category": "not_es3"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A6.10_T1": {
-		"category": "tbd"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A6.11_T1": {
-		"category": "tbd"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A6.1_T1": {
-		"category": "tbd"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A6.2_T1": {
-		"category": "tbd"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A6.3_T1": {
-		"category": "tbd"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A6.4_T1": {
-		"category": "tbd"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A6.5_T1": {
-		"category": "tbd"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A6.6_T1": {
-		"category": "tbd"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A6.7_T1": {
-		"category": "tbd"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A6.8_T1": {
-		"category": "tbd"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A6.9_T1": {
-		"category": "tbd"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A7.10_T1": {
-		"category": "tbd"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A7.11_T1": {
-		"category": "tbd"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A7.11_T2": {
-		"category": "tbd"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A7.1_T1": {
-		"category": "tbd"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A7.1_T2": {
-		"category": "tbd"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A7.2_T1": {
-		"category": "tbd"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A7.2_T2": {
-		"category": "tbd"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A7.3_T1": {
-		"category": "tbd"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A7.3_T2": {
-		"category": "tbd"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A7.4_T1": {
-		"category": "tbd"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A7.4_T2": {
-		"category": "tbd"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A7.5_T1": {
-		"category": "tbd"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A7.5_T2": {
-		"category": "tbd"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A7.6_T1": {
-		"category": "tbd"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A7.6_T2": {
-		"category": "tbd"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A7.7_T1": {
-		"category": "tbd"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A7.7_T2": {
-		"category": "tbd"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A7.8_T1": {
-		"category": "tbd"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A7.8_T2": {
-		"category": "tbd"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A7.9_T1": {
-		"category": "tbd"
-	},
-	"language/expressions/compound-assignment/S11.13.2_A7.9_T2": {
-		"category": "tbd"
-	},
-	"language/expressions/conditional/symbol-conditional-evaluation": {
-		"category": "not_es3"
-	},
-	"language/expressions/delete/S11.4.1_A1": {
-		"category": ""
-	},
-	"language/expressions/division/S11.5.2_A1": {
-		"category": ""
-	},
-	"language/expressions/does-not-equals/S11.9.2_A1": {
-		"category": ""
-	},
-	"language/expressions/does-not-equals/S11.9.2_A3.2": {
-		"category": ""
-	},
-	"language/expressions/does-not-equals/S11.9.2_A3.3": {
-		"category": ""
-	},
-	"language/expressions/does-not-equals/S11.9.2_A7.2": {
-		"category": ""
-	},
-	"language/expressions/does-not-equals/S11.9.2_A7.3": {
-		"category": ""
-	},
-	"language/expressions/does-not-equals/S11.9.2_A7.8": {
-		"category": ""
-	},
-	"language/expressions/does-not-equals/S11.9.2_A7.9": {
-		"category": ""
-	},
-	"language/expressions/equals/S11.9.1_A1": {
-		"category": ""
-	},
-	"language/expressions/equals/S11.9.1_A7.2": {
-		"category": ""
-	},
-	"language/expressions/equals/S11.9.1_A7.3": {
-		"category": ""
-	},
-	"language/expressions/equals/S11.9.1_A7.8": {
-		"category": ""
-	},
-	"language/expressions/equals/S11.9.1_A7.9": {
-		"category": ""
-	},
-	"language/expressions/equals/coerce-symbol-to-prim-err": {
-		"category": "not_es3"
-	},
-	"language/expressions/equals/coerce-symbol-to-prim-invocation": {
-		"category": "not_es3"
-	},
-	"language/expressions/equals/coerce-symbol-to-prim-return-obj": {
-		"category": "not_es3"
-	},
-	"language/expressions/equals/coerce-symbol-to-prim-return-prim": {
-		"category": "not_es3"
-	},
-	"language/expressions/equals/get-symbol-to-prim-err": {
-		"category": "tbd"
-	},
-	"language/expressions/equals/symbol-abstract-equality-comparison": {
-		"category": "not_es3"
-	},
-	"language/expressions/equals/symbol-strict-equality-comparison": {
-		"category": "not_es3"
-	},
-	"language/expressions/exponentiation/applying-the-exp-operator_A1": {
-		"category": "not_es3"
-	},
-	"language/expressions/exponentiation/applying-the-exp-operator_A10": {
-		"category": ""
-	},
-	"language/expressions/exponentiation/applying-the-exp-operator_A11": {
-		"category": "not_es3"
-	},
-	"language/expressions/exponentiation/applying-the-exp-operator_A12": {
-		"category": "not_es3"
-	},
-	"language/expressions/exponentiation/applying-the-exp-operator_A13": {
-		"category": "not_es3"
-	},
-	"language/expressions/exponentiation/applying-the-exp-operator_A14": {
-		"category": "not_es3"
-	},
-	"language/expressions/exponentiation/applying-the-exp-operator_A15": {
-		"category": "not_es3"
-	},
-	"language/expressions/exponentiation/applying-the-exp-operator_A16": {
-		"category": "not_es3"
-	},
-	"language/expressions/exponentiation/applying-the-exp-operator_A17": {
-		"category": "not_es3"
-	},
-	"language/expressions/exponentiation/applying-the-exp-operator_A18": {
-		"category": "not_es3"
-	},
-	"language/expressions/exponentiation/applying-the-exp-operator_A19": {
-		"category": "not_es3"
-	},
-	"language/expressions/exponentiation/applying-the-exp-operator_A2": {
-		"category": "not_es3"
-	},
-	"language/expressions/exponentiation/applying-the-exp-operator_A20": {
-		"category": "not_es3"
-	},
-	"language/expressions/exponentiation/applying-the-exp-operator_A21": {
-		"category": "not_es3"
-	},
-	"language/expressions/exponentiation/applying-the-exp-operator_A22": {
-		"category": "not_es3"
-	},
-	"language/expressions/exponentiation/applying-the-exp-operator_A23": {
-		"category": "not_es3"
-	},
-	"language/expressions/exponentiation/applying-the-exp-operator_A24": {
-		"category": "not_es3"
-	},
-	"language/expressions/exponentiation/applying-the-exp-operator_A3": {
-		"category": "not_es3"
-	},
-	"language/expressions/exponentiation/applying-the-exp-operator_A4": {
-		"category": "not_es3"
-	},
-	"language/expressions/exponentiation/applying-the-exp-operator_A5": {
-		"category": "not_es3"
-	},
-	"language/expressions/exponentiation/applying-the-exp-operator_A6": {
-		"category": "not_es3"
-	},
-	"language/expressions/exponentiation/applying-the-exp-operator_A7": {
-		"category": "not_es3"
-	},
-	"language/expressions/exponentiation/applying-the-exp-operator_A8": {
-		"category": "not_es3"
-	},
-	"language/expressions/exponentiation/applying-the-exp-operator_A9": {
-		"category": "not_es3"
-	},
-	"language/expressions/exponentiation/exp-assignment-operator": {
-		"category": "not_es3"
-	},
-	"language/expressions/exponentiation/exp-operator-evaluation-order": {
-		"category": "not_es3"
-	},
-	"language/expressions/exponentiation/exp-operator-precedence-unary-expression-semantics": {
-		"category": "not_es3"
-	},
-	"language/expressions/exponentiation/exp-operator-precedence-update-expression-semantics": {
-		"category": "not_es3"
-	},
-	"language/expressions/exponentiation/exp-operator": {
-		"category": "not_es3"
-	},
-	"language/expressions/function/name": {
-		"category": "not_es3"
-	},
-	"language/expressions/generators/has-instance": {
-		"category": "not_es3"
-	},
-	"language/expressions/generators/implicit-name": {
-		"category": "not_es3"
-	},
-	"language/expressions/generators/invoke-as-constructor": {
-		"category": "not_es3"
-	},
-	"language/expressions/generators/length-property-descriptor": {
-		"category": "not_es3"
-	},
-	"language/expressions/generators/name": {
-		"category": "not_es3"
-	},
-	"language/expressions/generators/no-name": {
-		"category": "not_es3"
-	},
-	"language/expressions/generators/no-yield": {
-		"category": "not_es3"
-	},
-	"language/expressions/generators/prototype-own-properties": {
-		"category": "not_es3"
-	},
-	"language/expressions/generators/prototype-property-descriptor": {
-		"category": "not_es3"
-	},
-	"language/expressions/generators/prototype-relation-to-function": {
-		"category": "not_es3"
-	},
-	"language/expressions/generators/prototype-typeof": {
-		"category": "not_es3"
-	},
-	"language/expressions/generators/prototype-uniqueness": {
-		"category": "not_es3"
-	},
-	"language/expressions/generators/prototype-value": {
-		"category": "not_es3"
-	},
-	"language/expressions/generators/return": {
-		"category": "not_es3"
-	},
-	"language/expressions/generators/yield-as-expression-with-rhs": {
-		"category": "not_es3"
-	},
-	"language/expressions/generators/yield-as-expression-without-rhs": {
-		"category": "not_es3"
-	},
-	"language/expressions/generators/yield-as-function-expression-binding-identifier": {
-		"category": "not_es3"
-	},
-	"language/expressions/generators/yield-as-identifier-in-nested-function": {
-		"category": "not_es3"
-	},
-	"language/expressions/generators/yield-as-literal-property-name": {
-		"category": "not_es3"
-	},
-	"language/expressions/generators/yield-as-property-name": {
-		"category": "not_es3"
-	},
-	"language/expressions/generators/yield-as-statement": {
-		"category": "not_es3"
-	},
-	"language/expressions/generators/yield-as-yield-operand": {
-		"category": "not_es3"
-	},
-	"language/expressions/generators/yield-newline": {
-		"category": "not_es3"
-	},
-	"language/expressions/generators/yield-star-before-newline": {
-		"category": "not_es3"
-	},
-	"language/expressions/greater-than/S11.8.2_A1": {
-		"category": ""
-	},
-	"language/expressions/greater-than-or-equal/S11.8.4_A1": {
-		"category": ""
-	},
-	"language/expressions/grouping/S11.1.6_A1": {
-		"category": ""
-	},
-	"language/expressions/in/S11.8.7_A1": {
-		"category": ""
-	},
-	"language/expressions/object/11.1.5_5-4-1": {
-		"category": "tbd"
-	},
-	"language/expressions/object/11.1.5_6-2-2-s": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/11.1.5_6-3-1": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/11.1.5_6-3-2": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/11.1.5_7-3-1": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/11.1.5_7-3-2": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/concise-generator": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/descriptor": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/fn-name-accessor-get": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/fn-name-accessor-set": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/fn-name-arrow": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/fn-name-class": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/fn-name-cover": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/fn-name-fn": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/fn-name-gen": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/getter": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/identifier-reference-property-get-access": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/let-non-strict-access": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/let-non-strict-syntax": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/method": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/not-defined": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/prop-def-id-eval-error-2": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/prop-def-id-eval-error": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/prop-def-id-get-error": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/prop-def-id-valid": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/properties-names-eval-arguments": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/setter": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/yield-non-strict-access": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/yield-non-strict-syntax": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/method-definition/fn-name-fn": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/method-definition/fn-name-gen": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/method-definition/generator-invoke-ctor": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/method-definition/generator-invoke-fn-no-strict": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/method-definition/generator-invoke-fn-strict": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/method-definition/generator-length": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/method-definition/generator-name-prop-string": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/method-definition/generator-name-prop-symbol": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/method-definition/generator-no-yield": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/method-definition/generator-params": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/method-definition/generator-prop-name-eval-error": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/method-definition/generator-prop-name-yield-expr": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/method-definition/generator-prop-name-yield-id": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/method-definition/generator-property-desc": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/method-definition/generator-prototype-prop": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/method-definition/generator-prototype": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/method-definition/generator-return": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/method-definition/generator-super-prop-body": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/method-definition/generator-super-prop-param": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/method-definition/name-invoke-ctor": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/method-definition/name-invoke-fn-no-strict": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/method-definition/name-invoke-fn-strict": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/method-definition/name-length": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/method-definition/name-name-prop-string": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/method-definition/name-name-prop-symbol": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/method-definition/name-param-id-yield": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/method-definition/name-param-init-yield": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/method-definition/name-params": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/method-definition/name-prop-name-eval-error": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/method-definition/name-prop-name-yield-expr": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/method-definition/name-prop-name-yield-id": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/method-definition/name-property-desc": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/method-definition/name-prototype-prop": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/method-definition/name-prototype": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/method-definition/name-super-prop-body": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/method-definition/name-super-prop-param": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/method-definition/yield-as-expression-with-rhs": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/method-definition/yield-as-expression-without-rhs": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/method-definition/yield-as-function-expression-binding-identifier": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/method-definition/yield-as-generator-method-binding-identifier": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/method-definition/yield-as-identifier-in-nested-function": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/method-definition/yield-as-literal-property-name": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/method-definition/yield-as-property-name": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/method-definition/yield-as-statement": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/method-definition/yield-as-yield-operand": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/method-definition/yield-newline": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/method-definition/yield-return": {
-		"category": "not_es3"
-	},
-	"language/expressions/object/method-definition/yield-star-before-newline": {
-		"category": "not_es3"
-	},
-	"language/types/object/S8.6.2_A8": {
-		"category": "not_es3"
-	},
-	"language/types/reference/8.7.2-7-s": {
-		"category": "not_es3"
-	},
-	"language/types/string/S8.4_A7.2": {
-		"category": ""
-	},
-	"language/types/string/S8.4_A7.3": {
-		"category": ""
-	},
-	"language/types/string/S8.4_A7.4": {
-		"category": ""
-	},
-	"language/white-space/S7.2_A1.5_T1": {
-		"category": ""
-	},
-	"language/expressions/in/S8.12.6_A2_T2": {
-		"category": ""
-	},
-	"language/expressions/instanceof/S11.8.6_A1": {
-		"category": ""
-	},
-	"language/expressions/instanceof/prototype-getter-with-object-throws": {
-		"category": "not_es3"
-	},
-	"language/expressions/instanceof/prototype-getter-with-object": {
-		"category": "not_es3"
-	},
-	"language/expressions/instanceof/symbol-hasinstance-get-err": {
-		"category": "not_es3"
-	},
-	"language/expressions/instanceof/symbol-hasinstance-invocation": {
-		"category": "not_es3"
-	},
-	"language/expressions/instanceof/symbol-hasinstance-not-callable": {
-		"category": "not_es3"
-	},
-	"language/expressions/instanceof/symbol-hasinstance-to-boolean": {
-		"category": "not_es3"
-	},
-	"language/expressions/left-shift/S11.7.1_A1": {
-		"category": ""
-	},
-	"language/expressions/less-than/S11.8.1_A1": {
-		"category": ""
-	},
-	"language/expressions/less-than-or-equal/S11.8.3_A1": {
-		"category": ""
-	},
-	"language/expressions/logical-and/S11.11.1_A1": {
-		"category": ""
-	},
-	"language/expressions/logical-and/symbol-logical-and-evaluation": {
-		"category": "not_es3"
-	},
-	"language/expressions/logical-not/S11.4.9_A1": {
-		"category": ""
-	},
-	"language/expressions/logical-not/symbol-logical-not-evaluation": {
-		"category": "not_es3"
-	},
-	"language/expressions/logical-or/S11.11.2_A1": {
-		"category": ""
-	},
-	"language/expressions/logical-or/symbol-logical-or-evaluation": {
-		"category": "not_es3"
-	},
-	"language/expressions/modulus/S11.5.3_A1": {
-		"category": ""
-	},
-	"language/expressions/multiplication/S11.5.1_A1": {
-		"category": ""
-	},
-	"language/expressions/new/S11.2.2_A1.1": {
-		"category": ""
-	},
-	"language/expressions/new/S11.2.2_A1.2": {
-		"category": ""
-	},
-	"language/expressions/postfix-decrement/S11.3.2_A1.2_T1": {
-		"category": ""
-	},
-	"language/expressions/postfix-decrement/S11.3.2_A5_T1": {
-		"category": "not_es3"
-	},
-	"language/expressions/postfix-decrement/S11.3.2_A5_T2": {
-		"category": "not_es3"
-	},
-	"language/expressions/postfix-decrement/S11.3.2_A5_T3": {
-		"category": "not_es3"
-	},
-	"language/expressions/postfix-decrement/S11.3.2_A5_T4": {
-		"category": "not_es3"
-	},
-	"language/expressions/postfix-decrement/S11.3.2_A5_T5": {
-		"category": "not_es3"
-	},
-	"language/expressions/postfix-decrement/S11.3.2_A6_T1": {
-		"category": "by_design"
-	},
-	"language/expressions/postfix-decrement/S11.3.2_A6_T2": {
-		"category": "by_design"
-	},
-	"language/expressions/postfix-increment/S11.3.1_A1.2_T1": {
-		"category": ""
-	},
-	"language/expressions/postfix-increment/S11.3.1_A5_T1": {
-		"category": "not_es3"
-	},
-	"language/expressions/postfix-increment/S11.3.1_A5_T2": {
-		"category": "not_es3"
-	},
-	"language/expressions/postfix-increment/S11.3.1_A5_T3": {
-		"category": "not_es3"
-	},
-	"language/expressions/postfix-increment/S11.3.1_A5_T4": {
-		"category": "not_es3"
-	},
-	"language/expressions/postfix-increment/S11.3.1_A5_T5": {
-		"category": "not_es3"
-	},
-	"language/expressions/postfix-increment/S11.3.1_A6_T1": {
-		"category": "by_design"
-	},
-	"language/expressions/postfix-increment/S11.3.1_A6_T2": {
-		"category": "by_design"
-	},
-	"language/expressions/prefix-decrement/S11.4.5_A1": {
-		"category": ""
-	},
-	"language/expressions/prefix-decrement/S11.4.5_A5_T1": {
-		"category": "not_es3"
-	},
-	"language/expressions/prefix-decrement/S11.4.5_A5_T2": {
-		"category": "not_es3"
-	},
-	"language/expressions/prefix-decrement/S11.4.5_A5_T3": {
-		"category": "not_es3"
-	},
-	"language/expressions/prefix-decrement/S11.4.5_A5_T4": {
-		"category": "not_es3"
-	},
-	"language/expressions/prefix-decrement/S11.4.5_A5_T5": {
-		"category": "not_es3"
-	},
-	"language/expressions/prefix-decrement/S11.4.5_A6_T1": {
-		"category": "by_design"
-	},
-	"language/expressions/prefix-decrement/S11.4.5_A6_T2": {
-		"category": "by_design"
-	},
-	"language/expressions/prefix-increment/S11.4.4_A1": {
-		"category": ""
-	},
-	"language/expressions/prefix-increment/S11.4.4_A5_T1": {
-		"category": "not_es3"
-	},
-	"language/expressions/prefix-increment/S11.4.4_A5_T2": {
-		"category": "not_es3"
-	},
-	"language/expressions/prefix-increment/S11.4.4_A5_T3": {
-		"category": "not_es3"
-	},
-	"language/expressions/prefix-increment/S11.4.4_A5_T4": {
-		"category": "not_es3"
-	},
-	"language/expressions/prefix-increment/S11.4.4_A5_T5": {
-		"category": "not_es3"
-	},
-	"language/expressions/prefix-increment/S11.4.4_A6_T1": {
-		"category": "by_design"
-	},
-	"language/expressions/prefix-increment/S11.4.4_A6_T2": {
-		"category": "by_design"
-	},
-	"language/expressions/property-accessors/S11.2.1_A1.1": {
-		"category": ""
-	},
-	"language/expressions/property-accessors/S11.2.1_A1.2": {
-		"category": ""
-	},
-	"language/expressions/right-shift/S11.7.2_A1": {
-		"category": ""
-	},
-	"language/expressions/strict-does-not-equals/S11.9.5_A1": {
-		"category": ""
-	},
-	"language/expressions/strict-equals/S11.9.4_A1": {
-		"category": ""
-	},
-	"language/expressions/subtraction/S11.6.2_A1": {
-		"category": ""
-	},
-	"language/expressions/tagged-template/cache-differing-expressions-eval": {
-		"category": "not_es3"
-	},
-	"language/expressions/tagged-template/cache-differing-expressions-new-function": {
-		"category": "not_es3"
-	},
-	"language/expressions/tagged-template/cache-differing-expressions": {
-		"category": "not_es3"
-	},
-	"language/expressions/tagged-template/cache-differing-raw-strings": {
-		"category": "not_es3"
-	},
-	"language/expressions/tagged-template/cache-differing-string-count": {
-		"category": "not_es3"
-	},
-	"language/expressions/tagged-template/cache-identical-source-eval": {
-		"category": "not_es3"
-	},
-	"language/expressions/tagged-template/cache-identical-source-new-function": {
-		"category": "not_es3"
-	},
-	"language/expressions/tagged-template/cache-identical-source": {
-		"category": "not_es3"
-	},
-	"language/expressions/tagged-template/call-expression-argument-list-evaluation": {
-		"category": "not_es3"
-	},
-	"language/expressions/tagged-template/call-expression-context-no-strict": {
-		"category": "not_es3"
-	},
-	"language/expressions/tagged-template/chained-application": {
-		"category": "not_es3"
-	},
-	"language/expressions/tagged-template/constructor-invocation": {
-		"category": "not_es3"
-	},
-	"language/expressions/tagged-template/member-expression-argument-list-evaluation": {
-		"category": "not_es3"
-	},
-	"language/expressions/tagged-template/member-expression-context": {
-		"category": "not_es3"
-	},
-	"language/expressions/tagged-template/template-object-frozen-non-strict": {
-		"category": "not_es3"
-	},
-	"language/expressions/tagged-template/template-object": {
-		"category": "not_es3"
-	},
-	"language/expressions/template-literal/evaluation-order": {
-		"category": "not_es3"
-	},
-	"language/expressions/template-literal/literal-expr-abrupt": {
-		"category": "not_es3"
-	},
-	"language/expressions/template-literal/literal-expr-function": {
-		"category": "not_es3"
-	},
-	"language/expressions/template-literal/literal-expr-member-expr": {
-		"category": "not_es3"
-	},
-	"language/expressions/template-literal/literal-expr-method": {
-		"category": "not_es3"
-	},
-	"language/expressions/template-literal/literal-expr-obj": {
-		"category": "not_es3"
-	},
-	"language/expressions/template-literal/literal-expr-primitive": {
-		"category": "not_es3"
-	},
-	"language/expressions/template-literal/literal-expr-template": {
-		"category": "not_es3"
-	},
-	"language/expressions/template-literal/literal-expr-tostr-error": {
-		"category": "not_es3"
-	},
-	"language/expressions/template-literal/middle-list-many-expr-abrupt": {
-		"category": "not_es3"
-	},
-	"language/expressions/template-literal/middle-list-many-expr-function": {
-		"category": "not_es3"
-	},
-	"language/expressions/template-literal/middle-list-many-expr-member-expr": {
-		"category": "not_es3"
-	},
-	"language/expressions/template-literal/middle-list-many-expr-method": {
-		"category": "not_es3"
-	},
-	"language/expressions/template-literal/middle-list-many-expr-obj": {
-		"category": "not_es3"
-	},
-	"language/expressions/template-literal/middle-list-many-expr-primitive": {
-		"category": "not_es3"
-	},
-	"language/expressions/template-literal/middle-list-many-expr-template": {
-		"category": "not_es3"
-	},
-	"language/expressions/template-literal/middle-list-many-expr-tostr-error": {
-		"category": "not_es3"
-	},
-	"language/expressions/template-literal/middle-list-one-expr-abrupt": {
-		"category": "not_es3"
-	},
-	"language/expressions/template-literal/middle-list-one-expr-function": {
-		"category": "not_es3"
-	},
-	"language/expressions/template-literal/middle-list-one-expr-member-expr": {
-		"category": "not_es3"
-	},
-	"language/expressions/template-literal/middle-list-one-expr-method": {
-		"category": "not_es3"
-	},
-	"language/expressions/template-literal/middle-list-one-expr-obj": {
-		"category": "not_es3"
-	},
-	"language/expressions/template-literal/middle-list-one-expr-primitive": {
-		"category": "not_es3"
-	},
-	"language/expressions/template-literal/middle-list-one-expr-template": {
-		"category": "not_es3"
-	},
-	"language/expressions/template-literal/middle-list-one-expr-tostr-error": {
-		"category": "not_es3"
-	},
-	"language/expressions/template-literal/no-sub": {
-		"category": "not_es3"
-	},
-	"language/expressions/template-literal/tv-character-escape-sequence": {
-		"category": "not_es3"
-	},
-	"language/expressions/template-literal/tv-hex-escape-sequence": {
-		"category": "not_es3"
-	},
-	"language/expressions/template-literal/tv-line-continuation": {
-		"category": "not_es3"
-	},
-	"language/expressions/template-literal/tv-line-terminator-sequence": {
-		"category": "not_es3"
-	},
-	"language/expressions/template-literal/tv-no-substitution": {
-		"category": "not_es3"
-	},
-	"language/expressions/template-literal/tv-null-character-escape-sequence": {
-		"category": "not_es3"
-	},
-	"language/expressions/template-literal/tv-template-character": {
-		"category": "not_es3"
-	},
-	"language/expressions/template-literal/tv-template-characters": {
-		"category": "not_es3"
-	},
-	"language/expressions/template-literal/tv-template-head": {
-		"category": "not_es3"
-	},
-	"language/expressions/template-literal/tv-template-middle": {
-		"category": "not_es3"
-	},
-	"language/expressions/template-literal/tv-template-tail": {
-		"category": "not_es3"
-	},
-	"language/expressions/template-literal/tv-utf16-escape-sequence": {
-		"category": "not_es3"
-	},
-	"language/expressions/template-literal/tv-zwnbsp": {
-		"category": "not_es3"
-	},
-	"language/expressions/typeof/symbol": {
-		"category": "not_es3"
-	},
-	"language/expressions/typeof/syntax": {
-		"category": ""
-	},
-	"language/expressions/unary-minus/S11.4.7_A1": {
-		"category": ""
-	},
-	"language/expressions/unary-plus/S11.4.6_A1": {
-		"category": ""
-	},
-	"language/expressions/unsigned-right-shift/S11.7.3_A1": {
-		"category": ""
-	},
-	"language/expressions/void/S11.4.2_A1": {
-		"category": ""
-	},
-	"language/expressions/yield/arguments-object-attributes": {
-		"category": "not_es3"
-	},
-	"language/expressions/yield/captured-free-vars": {
-		"category": "not_es3"
-	},
-	"language/expressions/yield/expr-value-specified": {
-		"category": "not_es3"
-	},
-	"language/expressions/yield/expr-value-unspecified": {
-		"category": "not_es3"
-	},
-	"language/expressions/yield/formal-parameters-after-reassignment-non-strict": {
-		"category": "not_es3"
-	},
-	"language/expressions/yield/formal-parameters": {
-		"category": "not_es3"
-	},
-	"language/expressions/yield/from-catch": {
-		"category": "not_es3"
-	},
-	"language/expressions/yield/from-try": {
-		"category": "not_es3"
-	},
-	"language/expressions/yield/from-with": {
-		"category": "not_es3"
-	},
-	"language/expressions/yield/star-array": {
-		"category": "not_es3"
-	},
-	"language/expressions/yield/star-iterable": {
-		"category": "not_es3"
-	},
-	"language/expressions/yield/star-string": {
-		"category": "not_es3"
-	},
-	"language/expressions/yield/then-return": {
-		"category": "not_es3"
-	},
-	"language/expressions/yield/within-for": {
-		"category": "not_es3"
-	},
-	"language/expressions/yield/yield-expr": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-1-s": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-10-s": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-100-s": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-100gs": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-102-s": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-102gs": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-103": {
-		"category": "tbd"
-	},
-	"language/function-code/10.4.3-1-105": {
-		"category": "tbd"
-	},
-	"language/function-code/10.4.3-1-10gs": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-12-s": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-12gs": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-14-s": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-14gs": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-16-s": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-16gs": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-2-s": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-3-s": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-36-s": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-36gs": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-37-s": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-37gs": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-38-s": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-38gs": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-39-s": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-39gs": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-4-s": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-40-s": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-40gs": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-41-s": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-41gs": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-42-s": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-42gs": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-43-s": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-43gs": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-44-s": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-44gs": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-45-s": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-45gs": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-46-s": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-46gs": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-47-s": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-47gs": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-48-s": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-48gs": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-49-s": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-49gs": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-50-s": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-50gs": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-51-s": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-51gs": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-52-s": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-52gs": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-53-s": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-53gs": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-58-s": {
-		"category": "tbd"
-	},
-	"language/function-code/10.4.3-1-58gs": {
-		"category": "tbd"
-	},
-	"language/function-code/10.4.3-1-59-s": {
-		"category": "tbd"
-	},
-	"language/function-code/10.4.3-1-59gs": {
-		"category": "tbd"
-	},
-	"language/function-code/10.4.3-1-60-s": {
-		"category": "tbd"
-	},
-	"language/function-code/10.4.3-1-60gs": {
-		"category": "tbd"
-	},
-	"language/function-code/10.4.3-1-61-s": {
-		"category": "tbd"
-	},
-	"language/function-code/10.4.3-1-61gs": {
-		"category": "tbd"
-	},
-	"language/function-code/10.4.3-1-62-s": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-62gs": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-63-s": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-63gs": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-64-s": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-64gs": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-65-s": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-65gs": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-66-s": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-66gs": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-67-s": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-67gs": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-68-s": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-68gs": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-71-s": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-71gs": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-72-s": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-72gs": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-73-s": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-73gs": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-76-s": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-76gs": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-77-s": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-77gs": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-78-s": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-78gs": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-79-s": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-79gs": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-8-s": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-80-s": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-80gs": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-8gs": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-95-s": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-95gs": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-96-s": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-96gs": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-97-s": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-97gs": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-98-s": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-98gs": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-99-s": {
-		"category": "not_es3"
-	},
-	"language/function-code/10.4.3-1-99gs": {
-		"category": "not_es3"
-	},
-	"language/function-code/eval-param-env-with-computed-key": {
-		"category": "not_es3"
-	},
-	"language/function-code/eval-param-env-with-prop-initializer": {
-		"category": "not_es3"
-	},
-	"language/identifier-resolution/unscopables": {
-		"category": "not_es3"
-	},
-	"language/identifiers/part-digits-via-escape-hex": {
-		"category": "tbd"
-	},
-	"language/identifiers/val-dollar-sign-via-escape-hex": {
-		"category": "tbd"
-	},
-	"language/identifiers/val-underscore-via-escape-hex": {
-		"category": "tbd"
-	},
-	"language/identifiers/vals-eng-alpha-lower-via-escape-hex": {
-		"category": "tbd"
-	},
-	"language/identifiers/vals-eng-alpha-upper-via-escape-hex": {
-		"category": "tbd"
-	},
-	"language/identifiers/vals-rus-alpha-lower-via-escape-hex": {
-		"category": "tbd"
-	},
-	"language/identifiers/vals-rus-alpha-upper-via-escape-hex": {
-		"category": "tbd"
-	},
-	"language/line-terminators/7.3-1": {
-		"category": ""
-	},
-	"language/line-terminators/7.3-2": {
-		"category": ""
-	},
-	"language/line-terminators/7.3-3": {
-		"category": ""
-	},
-	"language/line-terminators/7.3-4": {
-		"category": ""
-	},
-	"language/line-terminators/S7.3_A1.3": {
-		"category": ""
-	},
-	"language/line-terminators/S7.3_A1.4": {
-		"category": ""
-	},
-	"language/line-terminators/S7.3_A2.3": {
-		"category": ""
-	},
-	"language/line-terminators/S7.3_A2.4": {
-		"category": ""
-	},
-	"language/line-terminators/S7.3_A3.3_T2": {
-		"category": ""
-	},
-	"language/line-terminators/S7.3_A3.4_T2": {
-		"category": ""
-	},
-	"language/line-terminators/S7.3_A4_T3": {
-		"category": ""
-	},
-	"language/line-terminators/S7.3_A4_T4": {
-		"category": ""
-	},
-	"language/line-terminators/S7.3_A7_T1": {
-		"category": ""
-	},
-	"language/line-terminators/S7.3_A7_T2": {
-		"category": ""
-	},
-	"language/line-terminators/S7.3_A7_T3": {
-		"category": ""
-	},
-	"language/line-terminators/S7.3_A7_T4": {
-		"category": ""
-	},
-	"language/line-terminators/S7.3_A7_T5": {
-		"category": ""
-	},
-	"language/line-terminators/S7.3_A7_T6": {
-		"category": ""
-	},
-	"language/line-terminators/S7.3_A7_T7": {
-		"category": ""
-	},
-	"language/line-terminators/S7.3_A7_T8": {
-		"category": ""
-	},
-	"language/literals/regexp/7.8.5-2gs": {
-		"category": ""
-	},
-	"language/literals/regexp/S7.8.5_A1.1_T1": {
-		"category": ""
-	},
-	"language/literals/regexp/S7.8.5_A1.1_T2": {
-		"category": ""
-	},
-	"language/literals/regexp/S7.8.5_A1.4_T1": {
-		"category": ""
-	},
-	"language/literals/regexp/S7.8.5_A1.4_T2": {
-		"category": "not_es3"
-	},
-	"language/literals/regexp/S7.8.5_A2.1_T1": {
-		"category": ""
-	},
-	"language/literals/regexp/S7.8.5_A2.1_T2": {
-		"category": ""
-	},
-	"language/literals/regexp/S7.8.5_A2.4_T1": {
-		"category": ""
-	},
-	"language/literals/regexp/S7.8.5_A2.4_T2": {
-		"category": "not_es3"
-	},
-	"language/literals/regexp/S7.8.5_A3.1_T1": {
-		"category": ""
-	},
-	"language/literals/regexp/S7.8.5_A3.1_T2": {
-		"category": ""
-	},
-	"language/literals/regexp/S7.8.5_A3.1_T3": {
-		"category": ""
-	},
-	"language/literals/regexp/S7.8.5_A3.1_T4": {
-		"category": ""
-	},
-	"language/literals/regexp/S7.8.5_A3.1_T5": {
-		"category": ""
-	},
-	"language/literals/regexp/S7.8.5_A3.1_T6": {
-		"category": ""
-	},
-	"language/literals/regexp/S7.8.5_A3.1_T7": {
-		"category": ""
-	},
-	"language/literals/regexp/S7.8.5_A3.1_T8": {
-		"category": ""
-	},
-	"language/literals/regexp/S7.8.5_A3.1_T9": {
-		"category": ""
-	},
-	"language/literals/regexp/S7.8.5_A4.1": {
-		"category": ""
-	},
-	"language/literals/regexp/S7.8.5_A4.2": {
-		"category": ""
-	},
-	"language/literals/regexp/u-astral": {
-		"category": "not_es3"
-	},
-	"language/literals/regexp/u-case-mapping": {
-		"category": "not_es3"
-	},
-	"language/literals/regexp/u-surrogate-pairs": {
-		"category": "not_es3"
-	},
-	"language/literals/regexp/u-unicode-esc": {
-		"category": "not_es3"
-	},
-	"language/module-code/strict-mode": {
-		"category": "not_es3"
-	},
-	"language/reserved-words/7.6.1-1-1": {
-		"category": ""
-	},
-	"language/reserved-words/7.6.1-1-10": {
-		"category": ""
-	},
-	"language/reserved-words/7.6.1-1-11": {
-		"category": ""
-	},
-	"language/reserved-words/7.6.1-1-12": {
-		"category": ""
-	},
-	"language/reserved-words/7.6.1-1-13": {
-		"category": ""
-	},
-	"language/reserved-words/7.6.1-1-14": {
-		"category": ""
-	},
-	"language/reserved-words/7.6.1-1-15": {
-		"category": ""
-	},
-	"language/reserved-words/7.6.1-1-16": {
-		"category": ""
-	},
-	"language/reserved-words/7.6.1-1-2": {
-		"category": ""
-	},
-	"language/reserved-words/7.6.1-1-3": {
-		"category": ""
-	},
-	"language/reserved-words/7.6.1-1-4": {
-		"category": ""
-	},
-	"language/reserved-words/7.6.1-1-5": {
-		"category": ""
-	},
-	"language/reserved-words/7.6.1-1-6": {
-		"category": ""
-	},
-	"language/reserved-words/7.6.1-1-7": {
-		"category": ""
-	},
-	"language/reserved-words/7.6.1-1-8": {
-		"category": ""
-	},
-	"language/reserved-words/7.6.1-1-9": {
-		"category": ""
-	},
-	"language/reserved-words/7.6.1-2-1": {
-		"category": ""
-	},
-	"language/reserved-words/7.6.1-2-10": {
-		"category": ""
-	},
-	"language/reserved-words/7.6.1-2-11": {
-		"category": ""
-	},
-	"language/reserved-words/7.6.1-2-12": {
-		"category": ""
-	},
-	"language/reserved-words/7.6.1-2-13": {
-		"category": ""
-	},
-	"language/reserved-words/7.6.1-2-14": {
-		"category": ""
-	},
-	"language/reserved-words/7.6.1-2-15": {
-		"category": ""
-	},
-	"language/reserved-words/7.6.1-2-16": {
-		"category": ""
-	},
-	"language/reserved-words/7.6.1-2-2": {
-		"category": ""
-	},
-	"language/reserved-words/7.6.1-2-3": {
-		"category": ""
-	},
-	"language/reserved-words/7.6.1-2-4": {
-		"category": ""
-	},
-	"language/reserved-words/7.6.1-2-5": {
-		"category": ""
-	},
-	"language/reserved-words/7.6.1-2-6": {
-		"category": ""
-	},
-	"language/reserved-words/7.6.1-2-7": {
-		"category": ""
-	},
-	"language/reserved-words/7.6.1-2-8": {
-		"category": ""
-	},
-	"language/reserved-words/7.6.1-2-9": {
-		"category": ""
-	},
-	"language/reserved-words/7.6.1-3-1": {
-		"category": ""
-	},
-	"language/reserved-words/7.6.1-3-10": {
-		"category": ""
-	},
-	"language/reserved-words/7.6.1-3-11": {
-		"category": ""
-	},
-	"language/reserved-words/7.6.1-3-12": {
-		"category": ""
-	},
-	"language/reserved-words/7.6.1-3-13": {
-		"category": ""
-	},
-	"language/reserved-words/7.6.1-3-14": {
-		"category": ""
-	},
-	"language/reserved-words/7.6.1-3-15": {
-		"category": ""
-	},
-	"language/reserved-words/7.6.1-3-16": {
-		"category": ""
-	},
-	"language/reserved-words/7.6.1-3-2": {
-		"category": ""
-	},
-	"language/reserved-words/7.6.1-3-3": {
-		"category": ""
-	},
-	"language/reserved-words/7.6.1-3-4": {
-		"category": ""
-	},
-	"language/reserved-words/7.6.1-3-5": {
-		"category": ""
-	},
-	"language/reserved-words/7.6.1-3-6": {
-		"category": ""
-	},
-	"language/reserved-words/7.6.1-3-7": {
-		"category": ""
-	},
-	"language/reserved-words/7.6.1-3-8": {
-		"category": ""
-	},
-	"language/reserved-words/7.6.1-3-9": {
-		"category": ""
-	},
-	"language/reserved-words/await-module": {
-		"category": "not_es3"
-	},
-	"language/rest-parameters/array-pattern": {
-		"category": "not_es3"
-	},
-	"language/rest-parameters/arrow-function": {
-		"category": "not_es3"
-	},
-	"language/rest-parameters/expected-argument-count": {
-		"category": "not_es3"
-	},
-	"language/rest-parameters/no-alias-arguments": {
-		"category": "not_es3"
-	},
-	"language/rest-parameters/object-pattern": {
-		"category": "not_es3"
-	},
-	"language/rest-parameters/rest-index": {
-		"category": "not_es3"
-	},
-	"language/rest-parameters/rest-parameters-apply": {
-		"category": "not_es3"
-	},
-	"language/rest-parameters/rest-parameters-call": {
-		"category": "not_es3"
-	},
-	"language/rest-parameters/rest-parameters-produce-an-array": {
-		"category": "not_es3"
-	},
-	"language/rest-parameters/with-new-target": {
-		"category": "not_es3"
-	},
-	"language/statements/class/name": {
-		"category": "not_es3"
-	},
-	"language/statements/class/restricted-properties": {
-		"category": "not_es3"
-	},
-	"language/statements/class/arguments/access": {
-		"category": "not_es3"
-	},
-	"language/statements/class/arguments/default-constructor": {
-		"category": "not_es3"
-	},
-	"language/statements/class/definition/accessors": {
-		"category": "not_es3"
-	},
-	"language/statements/class/definition/basics": {
-		"category": "not_es3"
-	},
-	"language/statements/class/definition/constructable-but-no-prototype": {
-		"category": "not_es3"
-	},
-	"language/statements/class/definition/constructor-property": {
-		"category": "not_es3"
-	},
-	"language/statements/class/definition/constructor-strict-by-default": {
-		"category": "not_es3"
-	},
-	"language/statements/class/definition/constructor": {
-		"category": "not_es3"
-	},
-	"language/statements/class/definition/fn-name-accessor-get": {
-		"category": "not_es3"
-	},
-	"language/statements/class/definition/fn-name-accessor-set": {
-		"category": "not_es3"
-	},
-	"language/statements/class/definition/fn-name-gen-method": {
-		"category": "not_es3"
-	},
-	"language/statements/class/definition/fn-name-method": {
-		"category": "not_es3"
-	},
-	"language/statements/class/definition/fn-name-static-precedence": {
-		"category": "not_es3"
-	},
-	"language/statements/class/definition/getters-2": {
-		"category": "not_es3"
-	},
-	"language/statements/class/definition/getters": {
-		"category": "not_es3"
-	},
-	"language/statements/class/definition/implicit-constructor": {
-		"category": "not_es3"
-	},
-	"language/statements/class/definition/invalid-extends": {
-		"category": "not_es3"
-	},
-	"language/statements/class/definition/methods-gen-no-yield": {
-		"category": "not_es3"
-	},
-	"language/statements/class/definition/methods-gen-return": {
-		"category": "not_es3"
-	},
-	"language/statements/class/definition/methods-gen-yield-as-expression-with-rhs": {
-		"category": "not_es3"
-	},
-	"language/statements/class/definition/methods-gen-yield-as-expression-without-rhs": {
-		"category": "not_es3"
-	},
-	"language/statements/class/definition/methods-gen-yield-as-generator-method-binding-identifier": {
-		"category": "not_es3"
-	},
-	"language/statements/class/definition/methods-gen-yield-as-literal-property-name": {
-		"category": "not_es3"
-	},
-	"language/statements/class/definition/methods-gen-yield-as-property-name": {
-		"category": "not_es3"
-	},
-	"language/statements/class/definition/methods-gen-yield-as-statement": {
-		"category": "not_es3"
-	},
-	"language/statements/class/definition/methods-gen-yield-as-yield-operand": {
-		"category": "not_es3"
-	},
-	"language/statements/class/definition/methods-gen-yield-newline": {
-		"category": "not_es3"
-	},
-	"language/statements/class/definition/methods-gen-yield-star-before-newline": {
-		"category": "not_es3"
-	},
-	"language/statements/class/definition/methods-named-eval-arguments": {
-		"category": "not_es3"
-	},
-	"language/statements/class/definition/methods-restricted-properties": {
-		"category": "not_es3"
-	},
-	"language/statements/class/definition/methods": {
-		"category": "not_es3"
-	},
-	"language/statements/class/definition/numeric-property-names": {
-		"category": "not_es3"
-	},
-	"language/statements/class/definition/prototype-getter": {
-		"category": "not_es3"
-	},
-	"language/statements/class/definition/prototype-property": {
-		"category": "not_es3"
-	},
-	"language/statements/class/definition/prototype-setter": {
-		"category": "not_es3"
-	},
-	"language/statements/class/definition/prototype-wiring": {
-		"category": "not_es3"
-	},
-	"language/statements/class/definition/setters-2": {
-		"category": "not_es3"
-	},
-	"language/statements/class/definition/setters": {
-		"category": "not_es3"
-	},
-	"language/statements/class/definition/side-effects-in-extends": {
-		"category": "not_es3"
-	},
-	"language/statements/class/definition/side-effects-in-property-define": {
-		"category": "not_es3"
-	},
-	"language/statements/class/definition/this-access-restriction-2": {
-		"category": "not_es3"
-	},
-	"language/statements/class/definition/this-access-restriction": {
-		"category": "not_es3"
-	},
-	"language/statements/class/definition/this-check-ordering": {
-		"category": "not_es3"
-	},
-	"language/statements/class/name-binding/basic": {
-		"category": "not_es3"
-	},
-	"language/statements/class/name-binding/const": {
-		"category": "not_es3"
-	},
-	"language/statements/class/name-binding/expression": {
-		"category": "not_es3"
-	},
-	"language/statements/class/name-binding/in-extends-expression-assigned": {
-		"category": "not_es3"
-	},
-	"language/statements/class/name-binding/in-extends-expression-grouped": {
-		"category": "not_es3"
-	},
-	"language/statements/class/name-binding/in-extends-expression": {
-		"category": "not_es3"
-	},
-	"language/statements/class/strict-mode/arguments-caller": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/binding": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtins": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/class-definition-evaluation-empty-constructor-heritage-present": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/class-definition-null-proto-contains-return-override": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/class-definition-null-proto-missing-return-override": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/class-definition-null-proto": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/class-definition-superclass-generator": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/default-constructor-2": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/default-constructor": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/derived-class-return-override-with-boolean": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/derived-class-return-override-with-empty": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/derived-class-return-override-with-null": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/derived-class-return-override-with-number": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/derived-class-return-override-with-object": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/derived-class-return-override-with-string": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/derived-class-return-override-with-symbol": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/derived-class-return-override-with-this": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/derived-class-return-override-with-undefined": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/superclass-prototype-setter-constructor": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/superclass-prototype-setter-method-override": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/superclass-static-method-override": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/Array/contructor-calls-super-multiple-arguments": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/Array/contructor-calls-super-single-argument": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/Array/length": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/Array/regular-subclassing": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/Array/super-must-be-called": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/ArrayBuffer/regular-subclassing": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/ArrayBuffer/super-must-be-called": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/Boolean/regular-subclassing": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/Boolean/super-must-be-called": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/DataView/regular-subclassing": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/DataView/super-must-be-called": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/Date/regular-subclassing": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/Date/super-must-be-called": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/Error/message-property-assignment": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/Error/regular-subclassing": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/Error/super-must-be-called": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/Function/instance-length": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/Function/instance-name": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/Function/regular-subclassing": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/Function/super-must-be-called": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/GeneratorFunction/instance-length": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/GeneratorFunction/instance-name": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/GeneratorFunction/instance-prototype": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/GeneratorFunction/regular-subclassing": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/GeneratorFunction/super-must-be-called": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/Map/regular-subclassing": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/Map/super-must-be-called": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/NativeError/EvalError-message": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/NativeError/EvalError-name": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/NativeError/EvalError-super": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/NativeError/RangeError-message": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/NativeError/RangeError-name": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/NativeError/RangeError-super": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/NativeError/ReferenceError-message": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/NativeError/ReferenceError-name": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/NativeError/ReferenceError-super": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/NativeError/SyntaxError-message": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/NativeError/SyntaxError-name": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/NativeError/SyntaxError-super": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/NativeError/TypeError-message": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/NativeError/TypeError-name": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/NativeError/TypeError-super": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/NativeError/URIError-message": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/NativeError/URIError-name": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/NativeError/URIError-super": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/Number/regular-subclassing": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/Number/super-must-be-called": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/Object/constructor-return-undefined-throws": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/Object/constructor-returns-non-object": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/Object/regular-subclassing": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/Object/replacing-prototype": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/Promise/regular-subclassing": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/Promise/super-must-be-called": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/Proxy/no-prototype-throws": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/RegExp/lastIndex": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/RegExp/regular-subclassing": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/RegExp/super-must-be-called": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/Set/regular-subclassing": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/Set/super-must-be-called": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/String/length": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/String/regular-subclassing": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/String/super-must-be-called": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/Symbol/new-symbol-with-super-throws": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/Symbol/symbol-valid-as-extends-value": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/TypedArray/regular-subclassing": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/TypedArray/super-must-be-called": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/WeakMap/regular-subclassing": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/WeakMap/super-must-be-called": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/WeakSet/regular-subclassing": {
-		"category": "not_es3"
-	},
-	"language/statements/class/subclass/builtin-objects/WeakSet/super-must-be-called": {
-		"category": "not_es3"
-	},
-	"language/statements/class/super/in-constructor": {
-		"category": "not_es3"
-	},
-	"language/statements/class/super/in-getter": {
-		"category": "not_es3"
-	},
-	"language/statements/class/super/in-methods": {
-		"category": "not_es3"
-	},
-	"language/statements/class/super/in-setter": {
-		"category": "not_es3"
-	},
-	"language/statements/class/super/in-static-getter": {
-		"category": "not_es3"
-	},
-	"language/statements/class/super/in-static-methods": {
-		"category": "not_es3"
-	},
-	"language/statements/class/super/in-static-setter": {
-		"category": "not_es3"
-	},
-	"language/statements/class/syntax/class-body-has-direct-super-class-heritage": {
-		"category": "not_es3"
-	},
-	"language/statements/class/syntax/class-body-method-definition-super-property": {
-		"category": "not_es3"
-	},
-	"language/statements/class/syntax/class-declaration-binding-identifier-class-element-list": {
-		"category": "not_es3"
-	},
-	"language/statements/class/syntax/class-declaration-computed-method-definition": {
-		"category": "not_es3"
-	},
-	"language/statements/class/syntax/class-declaration-computed-method-generator-definition": {
-		"category": "not_es3"
-	},
-	"language/statements/class/syntax/class-declaration-heritage-identifier-reference-class-element-list": {
-		"category": "not_es3"
-	},
-	"language/statements/class/syntax/class-expression-binding-identifier-opt-class-element-list": {
-		"category": "not_es3"
-	},
-	"language/statements/class/syntax/class-expression-heritage-identifier-reference": {
-		"category": "not_es3"
-	},
-	"language/statements/class/syntax/class-expression": {
-		"category": "not_es3"
-	},
-	"language/statements/class/syntax/class-method-propname-constructor": {
-		"category": "not_es3"
-	},
-	"language/statements/class/syntax/early-errors/class-body-constructor-empty-missing-class-heritage": {
-		"category": "not_es3"
-	},
-	"language/statements/const/block-local-closure-get-before-initialization": {
-		"category": "not_es3"
-	},
-	"language/statements/const/block-local-use-before-initialization-in-declaration-statement": {
-		"category": "not_es3"
-	},
-	"language/statements/const/block-local-use-before-initialization-in-prior-statement": {
-		"category": "not_es3"
-	},
-	"language/statements/const/fn-name-arrow": {
-		"category": "not_es3"
-	},
-	"language/statements/const/fn-name-class": {
-		"category": "not_es3"
-	},
-	"language/statements/const/fn-name-cover": {
-		"category": "not_es3"
-	},
-	"language/statements/const/fn-name-fn": {
-		"category": "not_es3"
-	},
-	"language/statements/const/fn-name-gen": {
-		"category": "not_es3"
-	},
-	"language/statements/const/function-local-closure-get-before-initialization": {
-		"category": "not_es3"
-	},
-	"language/statements/const/function-local-use-before-initialization-in-declaration-statement": {
-		"category": "not_es3"
-	},
-	"language/statements/const/function-local-use-before-initialization-in-prior-statement": {
-		"category": "not_es3"
-	},
-	"language/statements/const/global-closure-get-before-initialization": {
-		"category": "not_es3"
-	},
-	"language/statements/const/global-use-before-initialization-in-declaration-statement": {
-		"category": "not_es3"
-	},
-	"language/statements/const/global-use-before-initialization-in-prior-statement": {
-		"category": "not_es3"
-	},
-	"language/statements/const/syntax/const-invalid-assignment-next-expression-for": {
-		"category": "not_es3"
-	},
-	"language/statements/const/syntax/const-invalid-assignment-statement-body-for-in": {
-		"category": "not_es3"
-	},
-	"language/statements/const/syntax/const-invalid-assignment-statement-body-for-of": {
-		"category": "not_es3"
-	},
-	"language/statements/const/syntax/const-outer-inner-let-bindings": {
-		"category": "not_es3"
-	},
-	"language/statements/const/syntax/const": {
-		"category": "not_es3"
-	},
-	"language/statements/const/syntax/with-initializer-case-expression-statement-list": {
-		"category": "not_es3"
-	},
-	"language/statements/const/syntax/with-initializer-default-statement-list": {
-		"category": "not_es3"
-	},
-	"language/statements/continue/labeled-continue": {
-		"category": "not_es3"
-	},
-	"language/statements/continue/nested-let-bound-for-loops-inner-continue": {
-		"category": "not_es3"
-	},
-	"language/statements/continue/nested-let-bound-for-loops-labeled-continue": {
-		"category": "not_es3"
-	},
-	"language/statements/continue/nested-let-bound-for-loops-outer-continue": {
-		"category": "not_es3"
-	},
-	"language/statements/continue/no-label-continue": {
-		"category": "not_es3"
-	},
-	"language/statements/continue/shadowing-loop-variable-in-same-scope-as-continue": {
-		"category": "not_es3"
-	},
-	"language/statements/continue/simple-and-labeled": {
-		"category": "not_es3"
-	},
-	"language/statements/do-while/cptn-abrupt-empty": {
-		"category": "tbd"
-	},
-	"language/statements/do-while/cptn-normal": {
-		"category": "tbd"
-	},
-	"language/statements/do-while/labeled-fn-stmt": {
-		"category": "tbd"
-	},
-	"language/statements/for/S12.6.3_A9.1": {
-		"category": "tbd"
-	},
-	"language/statements/for/S12.6.3_A9": {
-		"category": "tbd"
-	},
-	"language/statements/for/cptn-decl-expr-iter": {
-		"category": "tbd"
-	},
-	"language/statements/for/cptn-decl-expr-no-iter": {
-		"category": "tbd"
-	},
-	"language/statements/for/cptn-expr-expr-iter": {
-		"category": "tbd"
-	},
-	"language/statements/for/cptn-expr-expr-no-iter": {
-		"category": "tbd"
-	},
-	"language/statements/for/head-const-fresh-binding-per-iteration": {
-		"category": "not_es3"
-	},
-	"language/statements/for/head-let-fresh-binding-per-iteration": {
-		"category": "not_es3"
-	},
-	"language/statements/for/labeled-fn-stmt-expr": {
-		"category": "tbd"
-	},
-	"language/statements/for/labeled-fn-stmt-var": {
-		"category": "tbd"
-	},
-	"language/statements/for-in/12.6.4-1": {
-		"category": ""
-	},
-	"language/statements/for-in/12.6.4-2": {
-		"category": "tbd"
-	},
-	"language/statements/for-in/cptn-decl-abrupt-empty": {
-		"category": "tbd"
-	},
-	"language/statements/for-in/cptn-decl-itr": {
-		"category": "tbd"
-	},
-	"language/statements/for-in/cptn-decl-skip-itr": {
-		"category": "tbd"
-	},
-	"language/statements/for-in/cptn-decl-zero-itr": {
-		"category": "tbd"
-	},
-	"language/statements/for-in/cptn-expr-abrupt-empty": {
-		"category": "tbd"
-	},
-	"language/statements/for-in/cptn-expr-itr": {
-		"category": "tbd"
-	},
-	"language/statements/for-in/cptn-expr-skip-itr": {
-		"category": "tbd"
-	},
-	"language/statements/for-in/cptn-expr-zero-itr": {
-		"category": "tbd"
-	},
-	"language/statements/for-in/head-const-bound-names-fordecl-tdz": {
-		"category": "not_es3"
-	},
-	"language/statements/for-in/head-const-fresh-binding-per-iteration": {
-		"category": "not_es3"
-	},
-	"language/statements/for-in/head-decl-expr": {
-		"category": "not_es3"
-	},
-	"language/statements/for-in/head-let-bound-names-dup": {
-		"category": "not_es3"
-	},
-	"language/statements/for-in/head-let-bound-names-fordecl-tdz": {
-		"category": "not_es3"
-	},
-	"language/statements/for-in/head-let-fresh-binding-per-iteration": {
-		"category": "not_es3"
-	},
-	"language/statements/for-in/head-lhs-cover-non-asnmt-trgt": {
-		"category": "not_es3"
-	},
-	"language/statements/for-in/head-lhs-invalid-asnmt-ptrn-ary": {
-		"category": "not_es3"
-	},
-	"language/statements/for-in/head-lhs-non-asnmt-trgt": {
-		"category": "not_es3"
-	},
-	"language/statements/for-in/head-var-bound-names-dup": {
-		"category": "not_es3"
-	},
-	"language/statements/for-in/labeled-fn-stmt-lhs": {
-		"category": "not_es3"
-	},
-	"language/statements/for-in/labeled-fn-stmt-var": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/Array.prototype.Symbol.iterator": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/Array.prototype.entries": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/Array.prototype.keys": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/arguments-mapped": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/arguments-mapped-aliasing": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/arguments-mapped-mutation": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/arguments-unmapped": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/arguments-unmapped-aliasing": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/arguments-unmapped-mutation": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/array": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/array-contract": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/array-contract-expand": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/array-expand": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/array-expand-contract": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/array-key-get-error": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/body-dstr-assign": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/body-dstr-assign-error": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/body-put-error": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/break": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/break-from-catch": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/break-from-finally": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/break-from-try": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/break-label": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/break-label-from-catch": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/break-label-from-finally": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/break-label-from-try": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/continue": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/continue-from-catch": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/continue-from-finally": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/continue-from-try": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/continue-label": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/continue-label-from-catch": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/continue-label-from-finally": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/continue-label-from-try": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/cptn-decl-abrupt-empty": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/cptn-decl-itr": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/cptn-decl-no-itr": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/cptn-expr-abrupt-empty": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/cptn-expr-itr": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/cptn-expr-no-itr": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/float32array": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/float32array-mutate": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/float64array": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/float64array-mutate": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/generator": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/generator-close-via-break": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/generator-close-via-return": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/generator-close-via-throw": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/generator-next-error": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/generic-iterable": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/head-const-bound-names-fordecl-tdz": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/head-const-fresh-binding-per-iteration": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/head-expr-obj-iterator-method": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/head-expr-primitive-iterator-method": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/head-expr-to-obj": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/head-let-bound-names-fordecl-tdz": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/head-let-fresh-binding-per-iteration": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/head-lhs-cover": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/head-lhs-member": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/head-var-bound-names-dup": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/head-var-bound-names-in-stmt": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/head-var-bound-names-let": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/int16array": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/int16array-mutate": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/int32array": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/int32array-mutate": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/int8array": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/int8array-mutate": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/iterator-as-proxy": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/iterator-close-get-method-error": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/iterator-close-non-object": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/iterator-close-via-break": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/iterator-close-via-return": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/iterator-close-via-throw": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/iterator-next-error": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/iterator-next-reference": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/iterator-next-result-done-attr": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/iterator-next-result-type": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/iterator-next-result-value-attr": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/iterator-next-result-value-attr-error": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/map": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/map-contract": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/map-contract-expand": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/map-expand": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/map-expand-contract": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/nested": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/return": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/return-from-catch": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/return-from-finally": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/return-from-try": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/set": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/set-contract": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/set-contract-expand": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/set-expand": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/set-expand-contract": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/string-astral": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/string-astral-truncated": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/string-bmp": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/throw": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/throw-from-catch": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/throw-from-finally": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/uint16array": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/uint16array-mutate": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/uint32array": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/uint32array-mutate": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/uint8array": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/uint8array-mutate": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/uint8clampedarray": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/uint8clampedarray-mutate": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/yield": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/yield-from-catch": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/yield-from-finally": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/yield-from-try": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/yield-star": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/yield-star-from-catch": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/yield-star-from-finally": {
-		"category": "not_es3"
-	},
-	"language/statements/for-of/yield-star-from-try": {
-		"category": "not_es3"
-	},
-	"language/statements/function/13.0-10-s": {
-		"category": "not_es3"
-	},
-	"language/statements/function/13.0-11-s": {
-		"category": "not_es3"
-	},
-	"language/statements/function/13.0-13-s": {
-		"category": "not_es3"
-	},
-	"language/statements/function/13.0-14-s": {
-		"category": "not_es3"
-	},
-	"language/statements/function/13.0-15-s": {
-		"category": "not_es3"
-	},
-	"language/statements/function/13.0-16-s": {
-		"category": "not_es3"
-	},
-	"language/statements/function/13.0-7-s": {
-		"category": "not_es3"
-	},
-	"language/statements/function/13.1-15-s": {
-		"category": "not_es3"
-	},
-	"language/statements/function/13.1-16-s": {
-		"category": "not_es3"
-	},
-	"language/statements/function/13.1-17-s": {
-		"category": "not_es3"
-	},
-	"language/statements/function/13.1-18-s": {
-		"category": "not_es3"
-	},
-	"language/statements/function/13.1-19-s": {
-		"category": "not_es3"
-	},
-	"language/statements/function/13.1-20-s": {
-		"category": "not_es3"
-	},
-	"language/statements/function/13.1-21-s": {
-		"category": "not_es3"
-	},
-	"language/statements/function/13.1-22-s": {
-		"category": "not_es3"
-	},
-	"language/statements/function/13.1-23-s": {
-		"category": "not_es3"
-	},
-	"language/statements/function/13.1-24-s": {
-		"category": "not_es3"
-	},
-	"language/statements/function/13.1-25-s": {
-		"category": "not_es3"
-	},
-	"language/statements/function/13.1-26-s": {
-		"category": "not_es3"
-	},
-	"language/statements/function/13.1-27-s": {
-		"category": "not_es3"
-	},
-	"language/statements/function/13.1-28-s": {
-		"category": "not_es3"
-	},
-	"language/statements/function/13.1-29-s": {
-		"category": "not_es3"
-	},
-	"language/statements/function/13.1-30-s": {
-		"category": "not_es3"
-	},
-	"language/statements/function/13.1-31-s": {
-		"category": "not_es3"
-	},
-	"language/statements/function/13.1-32-s": {
-		"category": "not_es3"
-	},
-	"language/statements/function/13.1-33-s": {
-		"category": "not_es3"
-	},
-	"language/statements/function/13.1-34-s": {
-		"category": "not_es3"
-	},
-	"language/statements/function/13.1-35-s": {
-		"category": "not_es3"
-	},
-	"language/statements/function/13.1-36-s": {
-		"category": "not_es3"
-	},
-	"language/statements/function/13.1-37-s": {
-		"category": "not_es3"
-	},
-	"language/statements/function/13.1-38-s": {
-		"category": "not_es3"
-	},
-	"language/statements/function/13.1-39-s": {
-		"category": "not_es3"
-	},
-	"language/statements/function/13.1-40-s": {
-		"category": "not_es3"
-	},
-	"language/statements/function/13.1-41-s": {
-		"category": "not_es3"
-	},
-	"language/statements/function/13.1-42-s": {
-		"category": "not_es3"
-	},
-	"language/statements/function/13.2-10-s": {
-		"category": "not_es3"
-	},
-	"language/statements/function/13.2-13-s": {
-		"category": "not_es3"
-	},
-	"language/statements/function/13.2-14-s": {
-		"category": "not_es3"
-	},
 	"annexB/language/statements/labeled/function-declaration": {
 		"category": ""
 	},
-	"language/statements/variable/fn-name-gen": {
-		"category": "not_es3"
-	},
-	"language/statements/variable/fn-name-fn": {
-		"category": "not_es3"
-	},
-	"language/statements/let/block-local-closure-get-before-initialization": {
-		"category": "not_es3"
-	},
-	"language/statements/let/block-local-closure-set-before-initialization": {
-		"category": "not_es3"
-	},
-	"language/statements/let/block-local-use-before-initialization-in-declaration-statement": {
-		"category": "not_es3"
-	},
-	"language/statements/let/block-local-use-before-initialization-in-prior-statement": {
-		"category": "not_es3"
-	},
-	"language/statements/let/fn-name-arrow": {
-		"category": "not_es3"
-	},
-	"language/statements/let/fn-name-class": {
-		"category": "not_es3"
-	},
-	"language/statements/let/fn-name-cover": {
-		"category": "not_es3"
-	},
-	"language/statements/let/fn-name-fn": {
-		"category": "not_es3"
-	},
-	"language/statements/let/fn-name-gen": {
-		"category": "not_es3"
-	},
-	"language/statements/let/function-local-closure-get-before-initialization": {
-		"category": "not_es3"
-	},
-	"language/statements/let/function-local-closure-set-before-initialization": {
-		"category": "not_es3"
-	},
-	"language/statements/let/function-local-use-before-initialization-in-declaration-statement": {
-		"category": "not_es3"
-	},
-	"language/statements/let/function-local-use-before-initialization-in-prior-statement": {
-		"category": "not_es3"
-	},
-	"language/statements/let/global-closure-get-before-initialization": {
-		"category": "not_es3"
-	},
-	"language/statements/let/global-closure-set-before-initialization": {
-		"category": "not_es3"
-	},
-	"language/statements/let/global-use-before-initialization-in-declaration-statement": {
-		"category": "not_es3"
-	},
-	"language/statements/let/global-use-before-initialization-in-prior-statement": {
-		"category": "not_es3"
-	},
-	"language/statements/let/syntax/let-closure-inside-condition": {
-		"category": "not_es3"
-	},
-	"language/statements/let/syntax/let-closure-inside-initialization": {
-		"category": "not_es3"
-	},
-	"language/statements/let/syntax/let-closure-inside-next-expression": {
-		"category": "not_es3"
-	},
-	"language/statements/let/syntax/let-iteration-variable-is-freshly-allocated-for-each-iteration-multi-let-binding": {
-		"category": "not_es3"
-	},
-	"language/statements/let/syntax/let-iteration-variable-is-freshly-allocated-for-each-iteration-single-let-binding": {
-		"category": "not_es3"
-	},
-	"language/statements/let/syntax/let-let-declaration-split-across-two-lines": {
-		"category": "not_es3"
-	},
-	"language/statements/let/syntax/let-let-declaration-with-initializer-split-across-two-lines": {
-		"category": "not_es3"
-	},
-	"language/statements/let/syntax/let-outer-inner-let-bindings": {
-		"category": "not_es3"
-	},
-	"language/statements/let/syntax/let": {
-		"category": "not_es3"
-	},
-	"language/statements/let/syntax/with-initialisers-in-statement-positions-case-expression-statement-list": {
-		"category": "not_es3"
-	},
-	"language/statements/let/syntax/with-initialisers-in-statement-positions-default-statement-list": {
-		"category": "not_es3"
-	},
-	"language/statements/let/syntax/without-initialisers-in-statement-positions-case-expression-statement-list": {
-		"category": "not_es3"
-	},
-	"language/statements/let/syntax/without-initialisers-in-statement-positions-default-statement-list": {
-		"category": "not_es3"
-	},
-	"language/statements/generators/declaration": {
-		"category": "not_es3"
-	},
-	"language/statements/generators/has-instance": {
-		"category": "not_es3"
-	},
-	"language/statements/generators/invoke-as-constructor": {
-		"category": "not_es3"
-	},
-	"language/statements/generators/length-property-descriptor": {
-		"category": "not_es3"
-	},
-	"language/statements/generators/name": {
-		"category": "not_es3"
-	},
-	"language/statements/generators/no-yield": {
-		"category": "not_es3"
-	},
-	"language/statements/generators/prototype-own-properties": {
-		"category": "not_es3"
-	},
-	"language/statements/generators/prototype-property-descriptor": {
-		"category": "not_es3"
-	},
-	"language/statements/generators/prototype-relation-to-function": {
-		"category": "not_es3"
-	},
-	"language/statements/generators/prototype-typeof": {
-		"category": "not_es3"
-	},
-	"language/statements/generators/prototype-uniqueness": {
-		"category": "not_es3"
-	},
-	"language/statements/generators/prototype-value": {
-		"category": "not_es3"
-	},
-	"language/statements/generators/restricted-properties": {
-		"category": "not_es3"
-	},
-	"language/statements/generators/return": {
-		"category": "not_es3"
-	},
-	"language/statements/generators/yield-as-expression-with-rhs": {
-		"category": "not_es3"
-	},
-	"language/statements/generators/yield-as-expression-without-rhs": {
-		"category": "not_es3"
-	},
-	"language/statements/generators/yield-as-function-expression-binding-identifier": {
-		"category": "not_es3"
-	},
-	"language/statements/generators/yield-as-generator-declaration-binding-identifier": {
-		"category": "not_es3"
-	},
-	"language/statements/generators/yield-as-identifier-in-nested-function": {
-		"category": "not_es3"
-	},
-	"language/statements/generators/yield-as-literal-property-name": {
-		"category": "not_es3"
-	},
-	"language/statements/generators/yield-as-property-name": {
-		"category": "not_es3"
-	},
-	"language/statements/generators/yield-as-statement": {
-		"category": "not_es3"
-	},
-	"language/statements/generators/yield-as-yield-operand": {
-		"category": "not_es3"
-	},
-	"language/statements/generators/yield-newline": {
-		"category": "not_es3"
-	},
-	"language/statements/generators/yield-star-before-newline": {
-		"category": "not_es3"
-	},
-	"language/statements/with/12.10.1-1-s": {
-		"category": "not_es3"
-	},
-	"language/statements/with/12.10.1-12-s": {
-		"category": "not_es3"
-	},
-	"language/statements/with/12.10.1-2-s": {
-		"category": "not_es3"
-	},
-	"language/statements/with/12.10.1-3-s": {
-		"category": "not_es3"
-	},
-	"language/statements/with/12.10.1-4-s": {
-		"category": "not_es3"
-	},
-	"language/statements/with/12.10.1-8-s": {
-		"category": "not_es3"
-	},
-	"language/statements/with/12.10.1-9-s": {
-		"category": "not_es3"
-	},
-	"language/statements/function/13.2-15-1": {
-		"category": "tbd"
-	},
-	"language/statements/with/binding-blocked-by-unscopables": {
-		"category": "not_es3"
-	},
-	"language/statements/with/binding-not-blocked-by-unscopables-falsey-prop": {
-		"category": "not_es3"
-	},
-	"language/statements/with/binding-not-blocked-by-unscopables-non-obj": {
-		"category": "not_es3"
-	},
-	"language/statements/with/unscopables-get-err": {
-		"category": "not_es3"
-	},
-	"language/statements/with/unscopables-not-referenced-for-undef": {
-		"category": "not_es3"
-	},
-	"language/statements/with/unscopables-prop-get-err": {
-		"category": "not_es3"
-	},
-	"language/statements/function/13.2-17-1": {
-		"category": "tbd"
-	},
-	"language/statements/function/13.2-17-s": {
-		"category": "not_es3"
-	},
-	"language/statements/switch/cptn-dflt-b-abrupt-empty": {
-		"category": "not_es3"
-	},
-	"language/statements/variable/fn-name-cover": {
-		"category": "not_es3"
-	},
-	"language/statements/while/cptn-abrupt-empty": {
-		"category": "not_es3"
-	},
-	"language/statements/while/cptn-iter": {
-		"category": "not_es3"
-	},
-	"language/statements/while/cptn-no-iter": {
-		"category": "not_es3"
-	},
-	"language/statements/while/labeled-fn-stmt": {
-		"category": "by_design"
-	},
-	"language/statements/function/13.2-18-s": {
-		"category": "not_es3"
-	},
-	"language/statements/function/13.2-21-s": {
-		"category": "not_es3"
-	},
-	"language/statements/function/13.2-22-s": {
-		"category": "not_es3"
-	},
-	"language/statements/function/13.2-25-s": {
-		"category": "not_es3"
-	},
-	"language/statements/function/13.2-26-s": {
-		"category": "not_es3"
-	},
-	"language/statements/function/13.2-5-s": {
-		"category": "not_es3"
-	},
-	"language/statements/function/13.2-6-s": {
-		"category": "not_es3"
-	},
-	"language/statements/function/13.2-9-s": {
-		"category": "not_es3"
-	},
-	"language/statements/if/cptn-else-false-abrupt-empty": {
-		"category": "not_es3"
-	},
-	"language/statements/if/cptn-else-false-nrml": {
-		"category": "not_es3"
-	},
-	"language/statements/if/cptn-else-true-abrupt-empty": {
-		"category": "not_es3"
-	},
-	"language/statements/if/cptn-else-true-nrml": {
-		"category": "not_es3"
-	},
-	"language/statements/if/cptn-no-else-false": {
-		"category": "not_es3"
-	},
-	"language/statements/if/cptn-no-else-true-abrupt-empty": {
-		"category": "not_es3"
-	},
-	"language/statements/if/cptn-no-else-true-nrml": {
-		"category": "not_es3"
-	},
-	"language/statements/switch/cptn-a-abrupt-empty": {
-		"category": "not_es3"
-	},
-	"language/statements/switch/cptn-abrupt-empty": {
-		"category": "not_es3"
-	},
-	"language/statements/switch/cptn-b-abrupt-empty": {
-		"category": "not_es3"
-	},
-	"language/statements/switch/cptn-b-final": {
-		"category": "not_es3"
-	},
-	"language/statements/switch/cptn-dflt-abrupt-empty": {
-		"category": "not_es3"
-	},
-	"language/statements/switch/cptn-dflt-b-final": {
-		"category": "not_es3"
-	},
-	"language/statements/switch/cptn-dflt-final": {
-		"category": "not_es3"
-	},
-	"language/statements/switch/cptn-no-dflt-match-abrupt-empty": {
-		"category": "not_es3"
-	},
-	"language/statements/switch/cptn-no-dflt-match-final": {
-		"category": "not_es3"
-	},
-	"language/statements/switch/cptn-no-dflt-no-match": {
-		"category": "not_es3"
-	},
-	"language/statements/variable/fn-name-arrow": {
-		"category": "not_es3"
-	},
-	"language/statements/variable/fn-name-class": {
-		"category": "not_es3"
-	},
-	"language/statements/variable/12.2.1-22-s": {
-		"category": "not_es3"
-	},
-	"language/statements/with/cptn-abrupt-empty": {
-		"category": "not_es3"
-	},
-	"language/statements/with/cptn-nrml": {
-		"category": "not_es3"
-	},
-	"language/statements/function/13.2-18-1": {
-		"category": "not_es3"
-	},
-	"language/statements/try/cptn-finally-skip-catch": {
-		"category": "not_es3"
-	},
-	"language/statements/try/cptn-finally-wo-catch": {
-		"category": "not_es3"
-	},
-	"language/statements/try/cptn-try": {
-		"category": "not_es3"
-	},
-	"language/statements/try/cptn-finally-from-catch": {
-		"category": "not_es3"
-	},
-	"language/statements/try/cptn-catch": {
-		"category": "not_es3"
+	"annexB/language/statements/try/catch-redeclared-var-statement-captured": {
+		"category": ""
 	},
 	"built-ins/Array/S15.4.5.1_A1.3_T1": {
 		"category": "by_design"
@@ -4601,10 +245,13 @@
 	"built-ins/Array/Symbol.species/length": {
 		"category": "not_es3"
 	},
+	"built-ins/Array/Symbol.species/symbol-species": {
+		"category": "not_es3"
+	},
 	"built-ins/Array/Symbol.species/symbol-species-name": {
 		"category": "not_es3"
 	},
-	"built-ins/Array/Symbol.species/symbol-species": {
+	"built-ins/Array/from/Array.from-descriptor": {
 		"category": "not_es3"
 	},
 	"built-ins/Array/from/Array.from-name": {
@@ -4617,9 +264,6 @@
 		"category": "not_es3"
 	},
 	"built-ins/Array/from/calling-from-valid-1-noStrict": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/from/Array.from-descriptor": {
 		"category": "not_es3"
 	},
 	"built-ins/Array/from/calling-from-valid-2": {
@@ -4649,10 +293,10 @@
 	"built-ins/Array/from/iter-adv-err": {
 		"category": "not_es3"
 	},
-	"built-ins/Array/from/iter-cstm-ctor-err": {
+	"built-ins/Array/from/iter-cstm-ctor": {
 		"category": "not_es3"
 	},
-	"built-ins/Array/from/iter-cstm-ctor": {
+	"built-ins/Array/from/iter-cstm-ctor-err": {
 		"category": "not_es3"
 	},
 	"built-ins/Array/from/iter-get-iter-err": {
@@ -4676,16 +320,16 @@
 	"built-ins/Array/from/iter-map-fn-this-non-strict": {
 		"category": "not_es3"
 	},
-	"built-ins/Array/from/iter-set-elem-prop-err": {
-		"category": "not_es3"
-	},
 	"built-ins/Array/from/iter-set-elem-prop": {
 		"category": "not_es3"
 	},
-	"built-ins/Array/from/iter-set-length-err": {
+	"built-ins/Array/from/iter-set-elem-prop-err": {
 		"category": "not_es3"
 	},
 	"built-ins/Array/from/iter-set-length": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/from/iter-set-length-err": {
 		"category": "not_es3"
 	},
 	"built-ins/Array/from/mapfn-is-symbol-throws": {
@@ -4716,6 +360,3819 @@
 		"category": "not_es3"
 	},
 	"built-ins/Array/from/this-null": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/isArray/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/of/construct-this-with-the-number-of-arguments": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/of/creates-a-new-array-from-arguments": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/of/does-not-use-prototype-properties": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/of/length": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/of/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/of/of": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/of/return-a-custom-instance": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/of/return-a-new-array-object": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/of/return-abrupt-from-contructor": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/of/return-abrupt-from-data-property-using-proxy": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/of/return-abrupt-from-setting-length": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/of/sets-length": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/Symbol.iterator": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/Symbol.unscopables/prop-desc": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/Symbol.unscopables/value": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/concat/Array.prototype.concat_non-array": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/concat/Array.prototype.concat_spreadable-boolean-wrapper": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/concat/Array.prototype.concat_spreadable-function": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/concat/Array.prototype.concat_spreadable-getter-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/concat/Array.prototype.concat_spreadable-number-wrapper": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/concat/Array.prototype.concat_spreadable-reg-exp": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/concat/Array.prototype.concat_spreadable-sparse-object": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/concat/Array.prototype.concat_spreadable-string-wrapper": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/concat/is-concat-spreadable-get-err": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/concat/is-concat-spreadable-val-falsey": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/concat/is-concat-spreadable-val-truthy": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/concat/is-concat-spreadable-val-undefined": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/copyWithin/coerced-values-end": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/copyWithin/coerced-values-start": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/copyWithin/coerced-values-target": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/copyWithin/copyWithin": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/copyWithin/fill-holes": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/copyWithin/length": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/copyWithin/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/copyWithin/negative-end": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/copyWithin/negative-out-of-bounds-end": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/copyWithin/negative-out-of-bounds-start": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/copyWithin/negative-out-of-bounds-target": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/copyWithin/negative-start": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/copyWithin/negative-target": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/copyWithin/non-negative-out-of-bounds-end": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/copyWithin/non-negative-out-of-bounds-target-and-start": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/copyWithin/non-negative-target-and-start": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/copyWithin/non-negative-target-start-and-end": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/copyWithin/return-abrupt-from-delete-proxy-target": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/copyWithin/return-abrupt-from-end": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/copyWithin/return-abrupt-from-end-as-symbol": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/copyWithin/return-abrupt-from-get-start-value": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/copyWithin/return-abrupt-from-has-start": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/copyWithin/return-abrupt-from-set-target-value": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/copyWithin/return-abrupt-from-start": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/copyWithin/return-abrupt-from-start-as-symbol": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/copyWithin/return-abrupt-from-target": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/copyWithin/return-abrupt-from-target-as-symbol": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/copyWithin/return-abrupt-from-this-length": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/copyWithin/return-abrupt-from-this-length-as-symbol": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/copyWithin/return-this": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/copyWithin/undefined-end": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/entries/entries": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/entries/iteration": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/entries/iteration-mutable": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/entries/length": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/entries/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/entries/returns-iterator": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/entries/returns-iterator-from-object": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-0-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-0-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-1-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-1-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-1-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-1-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-1-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-1-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-1-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-1-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-1-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-1-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-1-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-1-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-1-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-2-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-2-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-2-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-2-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-2-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-2-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-2-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-2-17": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-2-18": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-2-19": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-2-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-2-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-2-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-2-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-2-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-2-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-2-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-2-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-3-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-3-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-3-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-3-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-3-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-3-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-3-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-3-16": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-3-17": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-3-18": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-3-19": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-3-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-3-20": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-3-21": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-3-22": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-3-23": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-3-24": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-3-25": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-3-29": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-3-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-3-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-3-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-3-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-3-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-3-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-3-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-4-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-4-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-4-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-4-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-4-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-4-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-5-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-5-1-s": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-5-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-5-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-5-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-5-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-5-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-5-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-5-16": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-5-17": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-5-18": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-5-19": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-5-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-5-21": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-5-22": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-5-23": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-5-24": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-5-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-5-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-5-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-5-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-5-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-5-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-b-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-b-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-b-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-b-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-b-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-b-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-b-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-b-16": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-b-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-b-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-b-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-b-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-b-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-b-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-b-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-b-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-i-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-i-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-i-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-i-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-i-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-i-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-i-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-i-16": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-i-17": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-i-18": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-i-19": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-i-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-i-20": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-i-21": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-i-22": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-i-23": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-i-25": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-i-26": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-i-27": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-i-28": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-i-29": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-i-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-i-30": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-i-31": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-i-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-i-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-i-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-i-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-i-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-i-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-ii-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-ii-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-ii-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-ii-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-ii-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-ii-16": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-ii-17": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-ii-18": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-ii-19": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-ii-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-ii-20": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-ii-21": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-ii-22": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-ii-23": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-ii-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-ii-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-ii-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-ii-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-ii-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-ii-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-ii-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-iii-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-iii-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-iii-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-iii-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-iii-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-iii-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-iii-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-iii-16": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-iii-17": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-iii-18": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-iii-19": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-iii-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-iii-20": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-iii-21": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-iii-22": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-iii-23": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-iii-24": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-iii-25": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-iii-27": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-iii-28": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-iii-29": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-iii-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-iii-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-iii-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-iii-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-iii-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-iii-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-7-c-iii-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-8-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-8-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-8-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-8-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-8-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-8-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-8-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-8-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-8-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-8-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-8-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/15.4.4.16-8-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/every/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/fill/coerced-indexes": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/fill/fill": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/fill/fill-values": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/fill/fill-values-custom-start-and-end": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/fill/fill-values-relative-end": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/fill/fill-values-relative-start": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/fill/length": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/fill/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/fill/return-abrupt-from-end": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/fill/return-abrupt-from-end-as-symbol": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/fill/return-abrupt-from-setting-property-value": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/fill/return-abrupt-from-start": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/fill/return-abrupt-from-start-as-symbol": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/fill/return-abrupt-from-this-length": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/fill/return-abrupt-from-this-length-as-symbol": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/fill/return-this": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-0-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-0-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-1-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-1-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-1-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-1-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-1-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-1-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-1-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-1-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-1-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-1-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-1-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-1-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-1-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-10-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-10-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-10-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-10-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-2-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-2-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-2-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-2-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-2-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-2-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-2-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-2-17": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-2-18": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-2-19": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-2-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-2-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-2-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-2-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-2-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-2-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-2-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-2-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-3-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-3-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-3-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-3-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-3-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-3-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-3-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-3-16": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-3-17": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-3-18": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-3-19": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-3-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-3-20": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-3-21": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-3-22": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-3-23": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-3-24": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-3-25": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-3-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-3-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-3-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-3-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-3-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-3-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-4-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-4-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-4-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-4-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-4-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-4-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-5-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-5-1-s": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-5-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-5-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-5-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-5-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-5-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-5-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-5-16": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-5-17": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-5-18": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-5-19": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-5-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-5-21": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-5-22": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-5-23": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-5-24": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-5-27": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-5-28": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-5-29": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-5-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-5-30": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-5-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-5-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-5-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-5-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-5-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-6-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-6-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-6-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-6-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-6-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-6-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-6-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-6-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-b-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-b-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-b-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-b-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-b-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-b-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-b-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-b-16": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-b-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-b-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-b-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-b-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-b-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-b-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-b-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-b-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-i-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-i-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-i-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-i-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-i-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-i-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-i-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-i-16": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-i-17": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-i-18": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-i-19": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-i-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-i-20": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-i-21": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-i-22": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-i-23": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-i-25": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-i-26": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-i-27": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-i-28": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-i-29": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-i-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-i-30": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-i-31": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-i-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-i-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-i-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-i-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-i-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-i-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-ii-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-ii-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-ii-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-ii-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-ii-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-ii-16": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-ii-17": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-ii-18": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-ii-19": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-ii-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-ii-20": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-ii-21": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-ii-22": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-ii-23": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-ii-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-ii-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-ii-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-ii-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-ii-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-ii-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-iii-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-iii-1-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-iii-1-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-iii-1-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-iii-1-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-iii-1-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-iii-1-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-iii-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-iii-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-iii-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-iii-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-iii-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-iii-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-iii-16": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-iii-17": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-iii-18": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-iii-19": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-iii-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-iii-20": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-iii-21": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-iii-22": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-iii-23": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-iii-24": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-iii-25": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-iii-26": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-iii-28": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-iii-29": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-iii-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-iii-30": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-iii-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-iii-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-iii-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-iii-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-iii-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/15.4.4.20-9-c-iii-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/filter/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/find/array-altered-during-loop": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/find/find": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/find/length": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/find/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/find/predicate-call-parameters": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/find/predicate-call-this-non-strict": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/find/predicate-called-for-each-array-property": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/find/predicate-not-called-on-empty-array": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/find/return-abrupt-from-predicate-call": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/find/return-abrupt-from-property": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/find/return-abrupt-from-this-length": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/find/return-abrupt-from-this-length-as-symbol": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/find/return-found-value-predicate-result-is-true": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/find/return-undefined-if-predicate-returns-false-value": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/findIndex/array-altered-during-loop": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/findIndex/findIndex": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/findIndex/length": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/findIndex/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/findIndex/predicate-call-parameters": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/findIndex/predicate-call-this-non-strict": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/findIndex/predicate-called-for-each-array-property": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/findIndex/predicate-not-called-on-empty-array": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/findIndex/return-abrupt-from-predicate-call": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/findIndex/return-abrupt-from-property": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/findIndex/return-abrupt-from-this-length": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/findIndex/return-abrupt-from-this-length-as-symbol": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/findIndex/return-index-predicate-result-is-true": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/findIndex/return-negative-one-if-predicate-returns-false-value": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-0-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-0-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-1-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-1-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-1-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-1-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-1-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-1-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-1-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-1-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-1-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-1-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-1-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-1-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-1-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-2-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-2-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-2-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-2-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-2-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-2-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-2-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-2-17": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-2-18": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-2-19": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-2-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-2-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-2-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-2-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-2-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-2-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-2-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-2-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-3-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-3-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-3-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-3-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-3-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-3-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-3-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-3-16": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-3-17": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-3-18": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-3-19": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-3-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-3-20": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-3-21": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-3-23": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-3-24": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-3-25": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-3-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-3-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-3-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-3-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-3-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-3-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-4-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-4-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-4-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-4-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-4-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-4-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-5-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-5-1-s": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-5-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-5-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-5-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-5-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-5-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-5-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-5-16": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-5-17": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-5-18": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-5-19": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-5-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-5-21": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-5-22": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-5-23": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-5-24": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-5-25": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-5-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-5-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-5-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-5-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-5-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-5-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-b-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-b-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-b-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-b-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-b-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-b-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-b-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-b-16": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-b-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-b-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-b-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-b-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-b-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-b-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-b-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-b-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-c-i-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-c-i-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-c-i-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-c-i-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-c-i-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-c-i-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-c-i-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-c-i-16": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-c-i-17": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-c-i-18": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-c-i-19": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-c-i-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-c-i-20": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-c-i-21": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-c-i-22": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-c-i-23": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-c-i-25": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-c-i-26": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-c-i-27": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-c-i-28": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-c-i-29": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-c-i-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-c-i-30": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-c-i-31": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-c-i-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-c-i-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-c-i-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-c-i-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-c-i-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-c-i-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-c-ii-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-c-ii-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-c-ii-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-c-ii-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-c-ii-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-c-ii-16": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-c-ii-17": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-c-ii-18": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-c-ii-19": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-c-ii-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-c-ii-20": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-c-ii-21": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-c-ii-22": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-c-ii-23": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-c-ii-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-c-ii-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-c-ii-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-c-ii-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-c-ii-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-7-c-ii-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-8-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-8-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-8-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-8-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-8-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-8-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-8-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-8-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-8-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-8-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-8-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-8-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/15.4.4.18-8-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/S15.4.4.18_A1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/S15.4.4.18_A2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/forEach/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-0-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-0-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-1-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-1-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-1-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-1-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-1-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-1-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-1-17": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-1-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-1-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-1-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-1-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-1-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-1-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-1-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-10-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-10-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-2-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-2-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-2-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-2-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-2-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-2-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-2-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-2-17": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-2-18": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-2-19": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-2-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-2-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-2-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-2-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-2-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-2-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-2-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-2-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-3-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-3-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-3-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-3-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-3-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-3-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-3-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-3-16": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-3-17": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-3-18": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-3-19": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-3-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-3-20": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-3-21": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-3-22": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-3-23": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-3-24": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-3-25": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-3-28": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-3-29": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-3-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-3-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-3-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-3-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-3-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-3-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-3-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-4-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-4-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-4-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-4-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-4-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-4-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-4-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-4-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-4-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-4-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-4-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-5-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-5-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-5-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-5-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-5-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-5-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-5-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-5-16": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-5-17": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-5-18": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-5-19": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-5-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-5-20": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-5-21": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-5-22": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-5-23": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-5-24": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-5-25": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-5-26": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-5-27": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-5-29": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-5-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-5-31": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-5-32": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-5-33": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-5-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-5-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-5-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-5-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-5-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-5-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-6-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-7-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-7-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-7-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-7-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-7-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-8-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-8-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-8-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-8-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-a-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-a-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-a-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-a-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-a-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-a-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-a-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-a-16": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-a-17": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-a-18": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-a-19": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-a-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-a-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-a-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-a-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-a-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-a-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-a-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-a-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-b-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-b-i-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-b-i-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-b-i-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-b-i-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-b-i-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-b-i-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-b-i-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-b-i-16": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-b-i-17": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-b-i-18": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-b-i-19": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-b-i-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-b-i-20": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-b-i-21": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-b-i-22": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-b-i-23": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-b-i-25": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-b-i-26": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-b-i-27": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-b-i-28": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-b-i-29": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-b-i-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-b-i-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-b-i-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-b-i-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-b-i-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-b-i-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-b-i-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-b-ii-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-b-ii-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-b-ii-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-b-ii-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-b-ii-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-b-ii-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-b-ii-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-b-ii-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-b-ii-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-b-ii-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-b-ii-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-b-iii-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/15.4.4.14-9-b-iii-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/fromindex-zero-conversion": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/indexOf/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/keys/iteration": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/keys/iteration-mutable": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/keys/keys": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/keys/length": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/keys/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/keys/returns-iterator": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/keys/returns-iterator-from-object": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-0-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-0-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-1-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-1-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-1-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-1-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-1-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-1-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-1-17": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-1-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-1-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-1-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-1-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-1-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-1-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-1-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-2-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-2-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-2-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-2-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-2-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-2-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-2-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-2-17": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-2-18": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-2-19": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-2-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-2-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-2-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-2-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-2-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-2-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-2-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-2-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-3-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-3-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-3-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-3-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-3-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-3-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-3-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-3-16": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-3-17": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-3-18": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-3-19": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-3-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-3-20": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-3-21": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-3-22": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-3-23": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-3-24": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-3-25": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-3-28": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-3-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-3-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-3-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-3-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-3-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-3-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-4-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-4-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-4-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-4-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-4-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-4-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-4-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-4-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-4-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-4-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-4-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-5-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-5-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-5-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-5-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-5-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-5-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-5-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-5-16": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-5-17": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-5-18": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-5-19": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-5-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-5-20": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-5-21": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-5-22": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-5-23": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-5-24": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-5-25": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-5-26": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-5-27": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-5-29": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-5-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-5-31": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-5-32": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-5-33": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-5-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-5-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-5-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-5-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-5-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-5-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-6-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-6-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-6-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-6-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-6-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-6-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-7-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-7-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-7-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-7-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-a-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-a-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-a-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-a-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-a-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-a-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-a-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-a-16": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-a-17": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-a-18": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-a-19": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-a-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-a-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-a-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-a-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-a-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-a-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-a-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-a-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-b-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-b-i-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-b-i-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-b-i-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-b-i-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-b-i-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-b-i-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-b-i-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-b-i-16": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-b-i-17": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-b-i-18": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-b-i-19": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-b-i-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-b-i-20": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-b-i-21": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-b-i-22": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-b-i-23": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-b-i-25": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-b-i-26": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-b-i-27": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-b-i-28": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-b-i-29": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-b-i-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-b-i-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-b-i-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-b-i-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-b-i-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-b-i-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-b-i-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-b-ii-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-b-ii-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-b-ii-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-b-ii-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-b-ii-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-b-ii-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-b-ii-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-b-ii-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-b-ii-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-b-ii-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-b-ii-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-b-iii-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-8-b-iii-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-9-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/15.4.4.15-9-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/fromindex-zero-conversion": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/lastIndexOf/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-0-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-0-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-1-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-1-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-1-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-1-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-1-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-1-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-1-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-1-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-1-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-1-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-1-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-1-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-1-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-2-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-2-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-2-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-2-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-2-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-2-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-2-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-2-17": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-2-18": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-2-19": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-2-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-2-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-2-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-2-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-2-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-2-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-2-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-2-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-3-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-3-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-3-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-3-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-3-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-3-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-3-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-3-16": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-3-17": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-3-18": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-3-19": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-3-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-3-20": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-3-21": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-3-23": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-3-24": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-3-25": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-3-28": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-3-29": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-3-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-3-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-3-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-3-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-3-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-3-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-3-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-4-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-4-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-4-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-4-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-4-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-4-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-5-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-5-1-s": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-5-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-5-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-5-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-5-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-5-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-5-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-5-16": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-5-17": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-5-18": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-5-19": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-5-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-5-21": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-5-22": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-5-23": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-5-24": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-5-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-5-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-5-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-5-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-5-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-5-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-6-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-6-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-b-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-b-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-b-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-b-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-b-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-b-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-b-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-b-16": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-b-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-b-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-b-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-b-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-b-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-b-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-b-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-b-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-c-i-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-c-i-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-c-i-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-c-i-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-c-i-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-c-i-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-c-i-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-c-i-16": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-c-i-17": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-c-i-18": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-c-i-19": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-c-i-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-c-i-20": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-c-i-21": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-c-i-22": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-c-i-23": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-c-i-25": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-c-i-26": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-c-i-27": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-c-i-28": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-c-i-29": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-c-i-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-c-i-30": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-c-i-31": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-c-i-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-c-i-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-c-i-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-c-i-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-c-i-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-c-i-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-c-ii-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-c-ii-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-c-ii-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-c-ii-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-c-ii-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-c-ii-16": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-c-ii-17": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-c-ii-18": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-c-ii-19": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-c-ii-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-c-ii-20": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-c-ii-21": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-c-ii-22": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-c-ii-23": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-c-ii-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-c-ii-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-c-ii-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-c-ii-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-c-ii-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-c-ii-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-c-iii-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-c-iii-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-c-iii-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-c-iii-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-8-c-iii-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-9-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-9-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-9-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-9-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-9-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-9-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-9-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-9-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-9-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-9-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-9-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-9-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/15.4.4.19-9-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/map/name": {
 		"category": "not_es3"
 	},
 	"built-ins/Array/prototype/push/S15.4.4.7_A4_T1": {
@@ -5276,6 +4733,867 @@
 	"built-ins/Array/prototype/reduce/15.4.4.21-9-c-i-23": {
 		"category": "not_es3"
 	},
+	"built-ins/Array/prototype/reduce/15.4.4.21-9-c-i-25": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduce/15.4.4.21-9-c-i-26": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduce/15.4.4.21-9-c-i-27": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduce/15.4.4.21-9-c-i-28": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduce/15.4.4.21-9-c-i-29": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduce/15.4.4.21-9-c-i-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduce/15.4.4.21-9-c-i-30": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduce/15.4.4.21-9-c-i-31": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduce/15.4.4.21-9-c-i-32": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduce/15.4.4.21-9-c-i-33": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduce/15.4.4.21-9-c-i-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduce/15.4.4.21-9-c-i-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduce/15.4.4.21-9-c-i-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduce/15.4.4.21-9-c-i-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduce/15.4.4.21-9-c-i-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduce/15.4.4.21-9-c-i-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduce/15.4.4.21-9-c-ii-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduce/15.4.4.21-9-c-ii-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduce/15.4.4.21-9-c-ii-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduce/15.4.4.21-9-c-ii-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduce/15.4.4.21-9-c-ii-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduce/15.4.4.21-9-c-ii-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduce/15.4.4.21-9-c-ii-16": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduce/15.4.4.21-9-c-ii-17": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduce/15.4.4.21-9-c-ii-18": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduce/15.4.4.21-9-c-ii-19": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduce/15.4.4.21-9-c-ii-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduce/15.4.4.21-9-c-ii-20": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduce/15.4.4.21-9-c-ii-21": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduce/15.4.4.21-9-c-ii-22": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduce/15.4.4.21-9-c-ii-23": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduce/15.4.4.21-9-c-ii-24": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduce/15.4.4.21-9-c-ii-25": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduce/15.4.4.21-9-c-ii-26": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduce/15.4.4.21-9-c-ii-27": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduce/15.4.4.21-9-c-ii-28": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduce/15.4.4.21-9-c-ii-29": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduce/15.4.4.21-9-c-ii-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduce/15.4.4.21-9-c-ii-30": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduce/15.4.4.21-9-c-ii-31": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduce/15.4.4.21-9-c-ii-32": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduce/15.4.4.21-9-c-ii-33": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduce/15.4.4.21-9-c-ii-34": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduce/15.4.4.21-9-c-ii-35": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduce/15.4.4.21-9-c-ii-37": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduce/15.4.4.21-9-c-ii-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduce/15.4.4.21-9-c-ii-4-s": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduce/15.4.4.21-9-c-ii-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduce/15.4.4.21-9-c-ii-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduce/15.4.4.21-9-c-ii-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduce/15.4.4.21-9-c-ii-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduce/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-0-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-0-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-1-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-1-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-1-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-1-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-1-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-1-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-1-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-1-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-1-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-1-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-1-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-1-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-1-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-10-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-10-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-10-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-10-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-10-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-10-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-10-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-10-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-2-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-2-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-2-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-2-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-2-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-2-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-2-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-2-17": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-2-18": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-2-19": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-2-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-2-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-2-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-2-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-2-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-2-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-2-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-2-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-3-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-3-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-3-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-3-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-3-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-3-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-3-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-3-16": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-3-17": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-3-18": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-3-19": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-3-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-3-20": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-3-21": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-3-22": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-3-23": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-3-24": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-3-25": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-3-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-3-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-3-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-3-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-3-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-3-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-4-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-4-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-4-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-4-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-4-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-4-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-5-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-5-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-5-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-5-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-5-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-7-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-7-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-7-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-7-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-7-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-7-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-7-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-7-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-7-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-7-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-7-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-8-b-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-8-b-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-8-b-ii-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-8-b-ii-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-8-b-iii-1-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-8-b-iii-1-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-8-b-iii-1-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-8-b-iii-1-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-8-b-iii-1-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-8-b-iii-1-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-8-b-iii-1-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-8-b-iii-1-16": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-8-b-iii-1-17": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-8-b-iii-1-18": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-8-b-iii-1-19": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-8-b-iii-1-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-8-b-iii-1-20": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-8-b-iii-1-21": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-8-b-iii-1-22": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-8-b-iii-1-23": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-8-b-iii-1-25": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-8-b-iii-1-26": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-8-b-iii-1-27": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-8-b-iii-1-28": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-8-b-iii-1-29": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-8-b-iii-1-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-8-b-iii-1-30": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-8-b-iii-1-31": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-8-b-iii-1-32": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-8-b-iii-1-33": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-8-b-iii-1-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-8-b-iii-1-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-8-b-iii-1-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-8-b-iii-1-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-8-b-iii-1-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-8-b-iii-1-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-8-c-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-8-c-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-8-c-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-8-c-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-8-c-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-b-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-b-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-b-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-b-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-b-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-b-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-b-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-b-16": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-b-17": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-b-18": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-b-19": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-b-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-b-20": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-b-21": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-b-22": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-b-23": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-b-24": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-b-25": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-b-26": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-b-27": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-b-28": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-b-29": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-b-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-b-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-b-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-b-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-b-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-b-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-b-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-i-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-i-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-i-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-i-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-i-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-i-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-i-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-i-16": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-i-17": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-i-18": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-i-19": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-i-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-i-20": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-i-21": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-i-22": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-i-23": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-i-25": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-i-26": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-i-27": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-i-28": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-i-29": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-i-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-i-30": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-i-31": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-i-32": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-i-33": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-i-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-i-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-i-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-i-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-i-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-i-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-ii-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-ii-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-ii-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-ii-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-ii-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-ii-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-ii-16": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-ii-17": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-ii-18": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-ii-19": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-ii-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-ii-20": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-ii-21": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-ii-22": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-ii-23": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-ii-24": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-ii-25": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-ii-26": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-ii-27": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-ii-28": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-ii-29": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-ii-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-ii-30": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-ii-31": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-ii-32": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-ii-33": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-ii-34": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-ii-35": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-ii-37": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-ii-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-ii-4-s": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-ii-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-ii-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-ii-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/15.4.4.22-9-c-ii-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/reduceRight/name": {
+		"category": "not_es3"
+	},
 	"built-ins/Array/prototype/reverse/S15.4.4.8_A3_T3": {
 		"category": "not_es3"
 	},
@@ -5288,13 +5606,628 @@
 	"built-ins/Array/prototype/slice/S15.4.4.10_A3_T3": {
 		"category": "not_es3"
 	},
+	"built-ins/Array/prototype/some/15.4.4.17-0-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-0-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-1-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-1-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-1-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-1-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-1-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-1-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-1-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-1-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-1-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-1-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-1-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-1-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-1-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-2-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-2-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-2-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-2-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-2-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-2-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-2-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-2-17": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-2-18": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-2-19": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-2-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-2-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-2-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-2-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-2-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-2-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-2-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-2-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-3-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-3-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-3-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-3-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-3-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-3-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-3-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-3-16": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-3-17": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-3-18": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-3-19": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-3-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-3-20": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-3-21": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-3-22": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-3-23": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-3-24": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-3-25": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-3-28": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-3-29": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-3-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-3-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-3-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-3-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-3-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-3-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-3-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-4-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-4-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-4-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-4-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-4-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-4-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-5-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-5-1-s": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-5-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-5-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-5-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-5-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-5-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-5-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-5-16": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-5-17": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-5-18": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-5-19": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-5-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-5-21": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-5-22": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-5-23": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-5-24": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-5-25": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-5-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-5-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-5-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-5-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-5-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-5-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-b-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-b-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-b-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-b-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-b-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-b-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-b-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-b-16": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-b-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-b-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-b-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-b-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-b-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-b-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-b-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-b-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-i-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-i-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-i-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-i-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-i-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-i-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-i-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-i-16": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-i-17": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-i-18": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-i-19": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-i-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-i-20": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-i-21": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-i-22": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-i-23": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-i-25": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-i-26": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-i-27": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-i-28": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-i-29": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-i-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-i-30": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-i-31": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-i-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-i-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-i-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-i-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-i-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-i-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-ii-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-ii-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-ii-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-ii-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-ii-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-ii-16": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-ii-17": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-ii-18": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-ii-19": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-ii-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-ii-20": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-ii-21": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-ii-22": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-ii-23": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-ii-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-ii-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-ii-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-ii-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-ii-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-ii-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-ii-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-iii-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-iii-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-iii-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-iii-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-iii-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-iii-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-iii-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-iii-16": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-iii-17": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-iii-18": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-iii-19": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-iii-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-iii-20": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-iii-21": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-iii-22": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-iii-23": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-iii-24": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-iii-25": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-iii-26": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-iii-28": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-iii-29": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-iii-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-iii-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-iii-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-iii-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-iii-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-iii-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-7-c-iii-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-8-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-8-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-8-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-8-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-8-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-8-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-8-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-8-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-8-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-8-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-8-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/15.4.4.17-8-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/some/name": {
+		"category": "not_es3"
+	},
 	"built-ins/Array/prototype/sort/S15.4.4.11_A4_T3": {
 		"category": "not_es3"
 	},
 	"built-ins/Array/prototype/sort/S15.4.4.11_A8": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/concat/Array.prototype.concat_non-array": {
 		"category": "not_es3"
 	},
 	"built-ins/Array/prototype/splice/S15.4.4.12_A3_T1": {
@@ -5310,6 +6243,1389 @@
 		"category": "not_es3"
 	},
 	"built-ins/Array/prototype/unshift/S15.4.4.13_A3_T2": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/values/iteration": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/values/iteration-mutable": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/values/length": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/values/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/values/prop-desc": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/values/returns-iterator": {
+		"category": "not_es3"
+	},
+	"built-ins/Array/prototype/values/returns-iterator-from-object": {
+		"category": "not_es3"
+	},
+	"built-ins/ArrayBuffer/Symbol.species/length": {
+		"category": "not_es3"
+	},
+	"built-ins/ArrayBuffer/Symbol.species/symbol-species": {
+		"category": "not_es3"
+	},
+	"built-ins/ArrayBuffer/Symbol.species/symbol-species-name": {
+		"category": "not_es3"
+	},
+	"built-ins/ArrayBuffer/allocation-limit": {
+		"category": "not_es3"
+	},
+	"built-ins/ArrayBuffer/data-allocation-after-object-creation": {
+		"category": "not_es3"
+	},
+	"built-ins/ArrayBuffer/isView/length": {
+		"category": "not_es3"
+	},
+	"built-ins/ArrayBuffer/isView/name": {
+		"category": "not_es3"
+	},
+	"built-ins/ArrayBuffer/length-is-absent": {
+		"category": "not_es3"
+	},
+	"built-ins/ArrayBuffer/length-is-not-number": {
+		"category": "not_es3"
+	},
+	"built-ins/ArrayBuffer/newtarget-prototype-is-not-object": {
+		"category": "not_es3"
+	},
+	"built-ins/ArrayBuffer/number-conversion": {
+		"category": "not_es3"
+	},
+	"built-ins/ArrayBuffer/positive-integer-length": {
+		"category": "not_es3"
+	},
+	"built-ins/ArrayBuffer/prototype-from-newtarget": {
+		"category": "not_es3"
+	},
+	"built-ins/ArrayBuffer/prototype/Symbol.toStringTag": {
+		"category": "not_es3"
+	},
+	"built-ins/ArrayBuffer/prototype/byteLength/length": {
+		"category": "not_es3"
+	},
+	"built-ins/ArrayBuffer/prototype/byteLength/name": {
+		"category": "not_es3"
+	},
+	"built-ins/ArrayBuffer/prototype/constructor": {
+		"category": "not_es3"
+	},
+	"built-ins/ArrayBuffer/prototype/slice/context-is-not-arraybuffer-object": {
+		"category": "not_es3"
+	},
+	"built-ins/ArrayBuffer/prototype/slice/context-is-not-object": {
+		"category": "not_es3"
+	},
+	"built-ins/ArrayBuffer/prototype/slice/descriptor": {
+		"category": "not_es3"
+	},
+	"built-ins/ArrayBuffer/prototype/slice/end-default-if-absent": {
+		"category": "not_es3"
+	},
+	"built-ins/ArrayBuffer/prototype/slice/end-default-if-undefined": {
+		"category": "not_es3"
+	},
+	"built-ins/ArrayBuffer/prototype/slice/end-exceeds-length": {
+		"category": "not_es3"
+	},
+	"built-ins/ArrayBuffer/prototype/slice/extensible": {
+		"category": "not_es3"
+	},
+	"built-ins/ArrayBuffer/prototype/slice/length": {
+		"category": "not_es3"
+	},
+	"built-ins/ArrayBuffer/prototype/slice/name": {
+		"category": "not_es3"
+	},
+	"built-ins/ArrayBuffer/prototype/slice/negative-end": {
+		"category": "not_es3"
+	},
+	"built-ins/ArrayBuffer/prototype/slice/negative-start": {
+		"category": "not_es3"
+	},
+	"built-ins/ArrayBuffer/prototype/slice/nonconstructor": {
+		"category": "not_es3"
+	},
+	"built-ins/ArrayBuffer/prototype/slice/number-conversion": {
+		"category": "not_es3"
+	},
+	"built-ins/ArrayBuffer/prototype/slice/species": {
+		"category": "not_es3"
+	},
+	"built-ins/ArrayBuffer/prototype/slice/species-constructor-is-not-object": {
+		"category": "not_es3"
+	},
+	"built-ins/ArrayBuffer/prototype/slice/species-constructor-is-undefined": {
+		"category": "not_es3"
+	},
+	"built-ins/ArrayBuffer/prototype/slice/species-is-not-constructor": {
+		"category": "not_es3"
+	},
+	"built-ins/ArrayBuffer/prototype/slice/species-is-not-object": {
+		"category": "not_es3"
+	},
+	"built-ins/ArrayBuffer/prototype/slice/species-is-null": {
+		"category": "not_es3"
+	},
+	"built-ins/ArrayBuffer/prototype/slice/species-is-undefined": {
+		"category": "not_es3"
+	},
+	"built-ins/ArrayBuffer/prototype/slice/species-returns-larger-arraybuffer": {
+		"category": "not_es3"
+	},
+	"built-ins/ArrayBuffer/prototype/slice/species-returns-not-arraybuffer": {
+		"category": "not_es3"
+	},
+	"built-ins/ArrayBuffer/prototype/slice/species-returns-same-arraybuffer": {
+		"category": "not_es3"
+	},
+	"built-ins/ArrayBuffer/prototype/slice/species-returns-smaller-arraybuffer": {
+		"category": "not_es3"
+	},
+	"built-ins/ArrayBuffer/prototype/slice/start-default-if-absent": {
+		"category": "not_es3"
+	},
+	"built-ins/ArrayBuffer/prototype/slice/start-default-if-undefined": {
+		"category": "not_es3"
+	},
+	"built-ins/ArrayBuffer/prototype/slice/start-exceeds-end": {
+		"category": "not_es3"
+	},
+	"built-ins/ArrayBuffer/prototype/slice/start-exceeds-length": {
+		"category": "not_es3"
+	},
+	"built-ins/ArrayBuffer/prototype/slice/tointeger-conversion-end": {
+		"category": "not_es3"
+	},
+	"built-ins/ArrayBuffer/prototype/slice/tointeger-conversion-start": {
+		"category": "not_es3"
+	},
+	"built-ins/ArrayBuffer/undefined-newtarget": {
+		"category": "not_es3"
+	},
+	"built-ins/ArrayBuffer/zero-length": {
+		"category": "not_es3"
+	},
+	"built-ins/ArrayIteratorPrototype/Symbol.toStringTag/property-descriptor": {
+		"category": "not_es3"
+	},
+	"built-ins/ArrayIteratorPrototype/Symbol.toStringTag/value-direct": {
+		"category": "not_es3"
+	},
+	"built-ins/ArrayIteratorPrototype/Symbol.toStringTag/value-from-to-string": {
+		"category": "not_es3"
+	},
+	"built-ins/DataView/prototype/Symbol.toStringTag": {
+		"category": "not_es3"
+	},
+	"built-ins/DataView/prototype/buffer/length": {
+		"category": "not_es3"
+	},
+	"built-ins/DataView/prototype/buffer/name": {
+		"category": "not_es3"
+	},
+	"built-ins/DataView/prototype/byteLength/length": {
+		"category": "not_es3"
+	},
+	"built-ins/DataView/prototype/byteLength/name": {
+		"category": "not_es3"
+	},
+	"built-ins/DataView/prototype/byteOffset/length": {
+		"category": "not_es3"
+	},
+	"built-ins/DataView/prototype/byteOffset/name": {
+		"category": "not_es3"
+	},
+	"built-ins/DataView/prototype/getFloat32/length": {
+		"category": "not_es3"
+	},
+	"built-ins/DataView/prototype/getFloat32/name": {
+		"category": "not_es3"
+	},
+	"built-ins/DataView/prototype/getFloat64/length": {
+		"category": "not_es3"
+	},
+	"built-ins/DataView/prototype/getFloat64/name": {
+		"category": "not_es3"
+	},
+	"built-ins/DataView/prototype/getInt16/length": {
+		"category": "not_es3"
+	},
+	"built-ins/DataView/prototype/getInt16/name": {
+		"category": "not_es3"
+	},
+	"built-ins/DataView/prototype/getInt32/length": {
+		"category": "not_es3"
+	},
+	"built-ins/DataView/prototype/getInt32/name": {
+		"category": "not_es3"
+	},
+	"built-ins/DataView/prototype/getInt8/length": {
+		"category": "not_es3"
+	},
+	"built-ins/DataView/prototype/getInt8/name": {
+		"category": "not_es3"
+	},
+	"built-ins/DataView/prototype/getUint16/length": {
+		"category": "not_es3"
+	},
+	"built-ins/DataView/prototype/getUint16/name": {
+		"category": "not_es3"
+	},
+	"built-ins/DataView/prototype/getUint32/length": {
+		"category": "not_es3"
+	},
+	"built-ins/DataView/prototype/getUint32/name": {
+		"category": "not_es3"
+	},
+	"built-ins/DataView/prototype/getUint8/length": {
+		"category": "not_es3"
+	},
+	"built-ins/DataView/prototype/getUint8/name": {
+		"category": "not_es3"
+	},
+	"built-ins/DataView/prototype/setFloat32/index-check-before-value-conversion": {
+		"category": "not_es3"
+	},
+	"built-ins/DataView/prototype/setFloat32/index-to-integer": {
+		"category": "not_es3"
+	},
+	"built-ins/DataView/prototype/setFloat32/length": {
+		"category": "not_es3"
+	},
+	"built-ins/DataView/prototype/setFloat32/name": {
+		"category": "not_es3"
+	},
+	"built-ins/DataView/prototype/setFloat32/range-check-after-value-conversion": {
+		"category": "not_es3"
+	},
+	"built-ins/DataView/prototype/setFloat64/index-check-before-value-conversion": {
+		"category": "not_es3"
+	},
+	"built-ins/DataView/prototype/setFloat64/index-to-integer": {
+		"category": "not_es3"
+	},
+	"built-ins/DataView/prototype/setFloat64/length": {
+		"category": "not_es3"
+	},
+	"built-ins/DataView/prototype/setFloat64/name": {
+		"category": "not_es3"
+	},
+	"built-ins/DataView/prototype/setFloat64/range-check-after-value-conversion": {
+		"category": "not_es3"
+	},
+	"built-ins/DataView/prototype/setInt16/index-check-before-value-conversion": {
+		"category": "not_es3"
+	},
+	"built-ins/DataView/prototype/setInt16/index-to-integer": {
+		"category": "not_es3"
+	},
+	"built-ins/DataView/prototype/setInt16/length": {
+		"category": "not_es3"
+	},
+	"built-ins/DataView/prototype/setInt16/name": {
+		"category": "not_es3"
+	},
+	"built-ins/DataView/prototype/setInt16/range-check-after-value-conversion": {
+		"category": "not_es3"
+	},
+	"built-ins/DataView/prototype/setInt32/index-check-before-value-conversion": {
+		"category": "not_es3"
+	},
+	"built-ins/DataView/prototype/setInt32/index-to-integer": {
+		"category": "not_es3"
+	},
+	"built-ins/DataView/prototype/setInt32/length": {
+		"category": "not_es3"
+	},
+	"built-ins/DataView/prototype/setInt32/name": {
+		"category": "not_es3"
+	},
+	"built-ins/DataView/prototype/setInt32/range-check-after-value-conversion": {
+		"category": "not_es3"
+	},
+	"built-ins/DataView/prototype/setInt8/index-check-before-value-conversion": {
+		"category": "not_es3"
+	},
+	"built-ins/DataView/prototype/setInt8/index-to-integer": {
+		"category": "not_es3"
+	},
+	"built-ins/DataView/prototype/setInt8/length": {
+		"category": "not_es3"
+	},
+	"built-ins/DataView/prototype/setInt8/name": {
+		"category": "not_es3"
+	},
+	"built-ins/DataView/prototype/setInt8/range-check-after-value-conversion": {
+		"category": "not_es3"
+	},
+	"built-ins/DataView/prototype/setUint16/index-check-before-value-conversion": {
+		"category": "not_es3"
+	},
+	"built-ins/DataView/prototype/setUint16/index-to-integer": {
+		"category": "not_es3"
+	},
+	"built-ins/DataView/prototype/setUint16/length": {
+		"category": "not_es3"
+	},
+	"built-ins/DataView/prototype/setUint16/name": {
+		"category": "not_es3"
+	},
+	"built-ins/DataView/prototype/setUint16/range-check-after-value-conversion": {
+		"category": "not_es3"
+	},
+	"built-ins/DataView/prototype/setUint32/index-check-before-value-conversion": {
+		"category": "not_es3"
+	},
+	"built-ins/DataView/prototype/setUint32/index-to-integer": {
+		"category": "not_es3"
+	},
+	"built-ins/DataView/prototype/setUint32/length": {
+		"category": "not_es3"
+	},
+	"built-ins/DataView/prototype/setUint32/name": {
+		"category": "not_es3"
+	},
+	"built-ins/DataView/prototype/setUint32/range-check-after-value-conversion": {
+		"category": "not_es3"
+	},
+	"built-ins/DataView/prototype/setUint8/index-check-before-value-conversion": {
+		"category": "not_es3"
+	},
+	"built-ins/DataView/prototype/setUint8/index-to-integer": {
+		"category": "not_es3"
+	},
+	"built-ins/DataView/prototype/setUint8/length": {
+		"category": "not_es3"
+	},
+	"built-ins/DataView/prototype/setUint8/name": {
+		"category": "not_es3"
+	},
+	"built-ins/DataView/prototype/setUint8/range-check-after-value-conversion": {
+		"category": "not_es3"
+	},
+	"built-ins/Date/now/15.9.4.4-0-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Date/now/15.9.4.4-0-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Date/now/15.9.4.4-0-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Date/now/15.9.4.4-0-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Date/now/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Date/prototype/Symbol.toPrimitive/hint-default-first-invalid": {
+		"category": "not_es3"
+	},
+	"built-ins/Date/prototype/Symbol.toPrimitive/hint-default-first-non-callable": {
+		"category": "not_es3"
+	},
+	"built-ins/Date/prototype/Symbol.toPrimitive/hint-default-first-valid": {
+		"category": "not_es3"
+	},
+	"built-ins/Date/prototype/Symbol.toPrimitive/hint-default-no-callables": {
+		"category": "not_es3"
+	},
+	"built-ins/Date/prototype/Symbol.toPrimitive/hint-invalid": {
+		"category": "not_es3"
+	},
+	"built-ins/Date/prototype/Symbol.toPrimitive/hint-number-first-invalid": {
+		"category": "not_es3"
+	},
+	"built-ins/Date/prototype/Symbol.toPrimitive/hint-number-first-non-callable": {
+		"category": "not_es3"
+	},
+	"built-ins/Date/prototype/Symbol.toPrimitive/hint-number-first-valid": {
+		"category": "not_es3"
+	},
+	"built-ins/Date/prototype/Symbol.toPrimitive/hint-number-no-callables": {
+		"category": "not_es3"
+	},
+	"built-ins/Date/prototype/Symbol.toPrimitive/hint-string-first-invalid": {
+		"category": "not_es3"
+	},
+	"built-ins/Date/prototype/Symbol.toPrimitive/hint-string-first-non-callable": {
+		"category": "not_es3"
+	},
+	"built-ins/Date/prototype/Symbol.toPrimitive/hint-string-first-valid": {
+		"category": "not_es3"
+	},
+	"built-ins/Date/prototype/Symbol.toPrimitive/hint-string-no-callables": {
+		"category": "not_es3"
+	},
+	"built-ins/Date/prototype/Symbol.toPrimitive/length": {
+		"category": "not_es3"
+	},
+	"built-ins/Date/prototype/Symbol.toPrimitive/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Date/prototype/Symbol.toPrimitive/prop-desc": {
+		"category": "not_es3"
+	},
+	"built-ins/Date/prototype/Symbol.toPrimitive/this-val-non-obj": {
+		"category": "not_es3"
+	},
+	"built-ins/Date/prototype/toISOString/15.9.5.43-0-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Date/prototype/toISOString/15.9.5.43-0-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Date/prototype/toISOString/15.9.5.43-0-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Date/prototype/toISOString/15.9.5.43-0-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Date/prototype/toISOString/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Date/prototype/toJSON/15.9.5.44-0-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Date/prototype/toJSON/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/Symbol.hasInstance/length": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/Symbol.hasInstance/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/Symbol.hasInstance/prop-desc": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/Symbol.hasInstance/this-val-bound-target": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/Symbol.hasInstance/this-val-not-callable": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/Symbol.hasInstance/this-val-poisoned-prototype": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/Symbol.hasInstance/this-val-prototype-non-obj": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/Symbol.hasInstance/value-get-prototype-of-err": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/Symbol.hasInstance/value-negative": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/Symbol.hasInstance/value-non-obj": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/Symbol.hasInstance/value-positive": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5-0-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5-0-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5-10-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5-11-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5-13.b-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5-13.b-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5-13.b-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5-13.b-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5-13.b-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5-13.b-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5-15-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5-15-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5-15-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5-15-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5-15-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5-16-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5-16-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5-2-16": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5-2-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5-2-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5-2-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5-2-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5-2-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5-2-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5-20-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5-20-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5-21-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5-21-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5-3-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5-6-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5-6-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5-6-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5-6-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5-6-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5-6-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5-6-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5-6-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5-6-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5-6-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5-6-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5-6-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5-8-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5-8-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5-9-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5-9-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5.1-4-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5.1-4-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5.1-4-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5.1-4-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5.1-4-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5.1-4-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5.1-4-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5.1-4-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5.1-4-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5.1-4-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5.1-4-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5.1-4-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5.1-4-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5.1-4-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5.1-4-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5.2-4-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5.2-4-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5.2-4-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5.2-4-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5.2-4-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5.2-4-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5.2-4-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5.2-4-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5.2-4-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5.2-4-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5.2-4-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5.2-4-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5.2-4-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/15.3.4.5.2-4-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/BoundFunction_restricted-properties": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/S15.3.4.5_A1": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/S15.3.4.5_A2": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/S15.3.4.5_A3": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/S15.3.4.5_A4": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/S15.3.4.5_A5": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/instance-name": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/instance-name-chained": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/instance-name-error": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/instance-name-non-string": {
+		"category": "not_es3"
+	},
+	"built-ins/Function/prototype/bind/name": {
+		"category": "not_es3"
+	},
+	"built-ins/GeneratorFunction/has-instance": {
+		"category": "not_es3"
+	},
+	"built-ins/GeneratorFunction/instance-name": {
+		"category": "not_es3"
+	},
+	"built-ins/GeneratorFunction/instance-restricted-properties": {
+		"category": "not_es3"
+	},
+	"built-ins/GeneratorFunction/invoked-as-constructor-no-arguments": {
+		"category": "not_es3"
+	},
+	"built-ins/GeneratorFunction/invoked-as-function-multiple-arguments": {
+		"category": "not_es3"
+	},
+	"built-ins/GeneratorFunction/invoked-as-function-no-arguments": {
+		"category": "not_es3"
+	},
+	"built-ins/GeneratorFunction/invoked-as-function-single-argument": {
+		"category": "not_es3"
+	},
+	"built-ins/GeneratorFunction/prototype/Symbol.toStringTag": {
+		"category": "not_es3"
+	},
+	"built-ins/GeneratorFunction/prototype/prototype": {
+		"category": "not_es3"
+	},
+	"built-ins/GeneratorPrototype/Symbol.toStringTag": {
+		"category": "not_es3"
+	},
+	"built-ins/GeneratorPrototype/constructor": {
+		"category": "not_es3"
+	},
+	"built-ins/GeneratorPrototype/next/consecutive-yields": {
+		"category": "not_es3"
+	},
+	"built-ins/GeneratorPrototype/next/context-method-invocation": {
+		"category": "not_es3"
+	},
+	"built-ins/GeneratorPrototype/next/from-state-executing": {
+		"category": "not_es3"
+	},
+	"built-ins/GeneratorPrototype/next/incorrect-context": {
+		"category": "not_es3"
+	},
+	"built-ins/GeneratorPrototype/next/length": {
+		"category": "not_es3"
+	},
+	"built-ins/GeneratorPrototype/next/lone-return": {
+		"category": "not_es3"
+	},
+	"built-ins/GeneratorPrototype/next/lone-yield": {
+		"category": "not_es3"
+	},
+	"built-ins/GeneratorPrototype/next/name": {
+		"category": "not_es3"
+	},
+	"built-ins/GeneratorPrototype/next/no-control-flow": {
+		"category": "not_es3"
+	},
+	"built-ins/GeneratorPrototype/next/property-descriptor": {
+		"category": "not_es3"
+	},
+	"built-ins/GeneratorPrototype/next/result-prototype": {
+		"category": "not_es3"
+	},
+	"built-ins/GeneratorPrototype/next/return-yield-expr": {
+		"category": "not_es3"
+	},
+	"built-ins/GeneratorPrototype/return/from-state-completed": {
+		"category": "not_es3"
+	},
+	"built-ins/GeneratorPrototype/return/from-state-executing": {
+		"category": "not_es3"
+	},
+	"built-ins/GeneratorPrototype/return/from-state-suspended-start": {
+		"category": "not_es3"
+	},
+	"built-ins/GeneratorPrototype/return/incorrect-context": {
+		"category": "not_es3"
+	},
+	"built-ins/GeneratorPrototype/return/length": {
+		"category": "not_es3"
+	},
+	"built-ins/GeneratorPrototype/return/name": {
+		"category": "not_es3"
+	},
+	"built-ins/GeneratorPrototype/return/property-descriptor": {
+		"category": "not_es3"
+	},
+	"built-ins/GeneratorPrototype/return/try-catch-before-try": {
+		"category": "not_es3"
+	},
+	"built-ins/GeneratorPrototype/return/try-catch-following-catch": {
+		"category": "not_es3"
+	},
+	"built-ins/GeneratorPrototype/return/try-catch-within-catch": {
+		"category": "not_es3"
+	},
+	"built-ins/GeneratorPrototype/return/try-catch-within-try": {
+		"category": "not_es3"
+	},
+	"built-ins/GeneratorPrototype/return/try-finally-before-try": {
+		"category": "not_es3"
+	},
+	"built-ins/GeneratorPrototype/return/try-finally-following-finally": {
+		"category": "not_es3"
+	},
+	"built-ins/GeneratorPrototype/return/try-finally-nested-try-catch-within-catch": {
+		"category": "not_es3"
+	},
+	"built-ins/GeneratorPrototype/return/try-finally-nested-try-catch-within-finally": {
+		"category": "not_es3"
+	},
+	"built-ins/GeneratorPrototype/return/try-finally-nested-try-catch-within-inner-try": {
+		"category": "not_es3"
+	},
+	"built-ins/GeneratorPrototype/return/try-finally-nested-try-catch-within-outer-try-after-nested": {
+		"category": "not_es3"
+	},
+	"built-ins/GeneratorPrototype/return/try-finally-nested-try-catch-within-outer-try-before-nested": {
+		"category": "not_es3"
+	},
+	"built-ins/GeneratorPrototype/return/try-finally-within-finally": {
+		"category": "not_es3"
+	},
+	"built-ins/GeneratorPrototype/return/try-finally-within-try": {
+		"category": "not_es3"
+	},
+	"built-ins/GeneratorPrototype/throw/from-state-completed": {
+		"category": "not_es3"
+	},
+	"built-ins/GeneratorPrototype/throw/from-state-executing": {
+		"category": "not_es3"
+	},
+	"built-ins/GeneratorPrototype/throw/from-state-suspended-start": {
+		"category": "not_es3"
+	},
+	"built-ins/GeneratorPrototype/throw/incorrect-context": {
+		"category": "not_es3"
+	},
+	"built-ins/GeneratorPrototype/throw/length": {
+		"category": "not_es3"
+	},
+	"built-ins/GeneratorPrototype/throw/name": {
+		"category": "not_es3"
+	},
+	"built-ins/GeneratorPrototype/throw/property-descriptor": {
+		"category": "not_es3"
+	},
+	"built-ins/GeneratorPrototype/throw/try-catch-before-try": {
+		"category": "not_es3"
+	},
+	"built-ins/GeneratorPrototype/throw/try-catch-following-catch": {
+		"category": "not_es3"
+	},
+	"built-ins/GeneratorPrototype/throw/try-catch-within-catch": {
+		"category": "not_es3"
+	},
+	"built-ins/GeneratorPrototype/throw/try-catch-within-try": {
+		"category": "not_es3"
+	},
+	"built-ins/GeneratorPrototype/throw/try-finally-before-try": {
+		"category": "not_es3"
+	},
+	"built-ins/GeneratorPrototype/throw/try-finally-following-finally": {
+		"category": "not_es3"
+	},
+	"built-ins/GeneratorPrototype/throw/try-finally-nested-try-catch-within-catch": {
+		"category": "not_es3"
+	},
+	"built-ins/GeneratorPrototype/throw/try-finally-nested-try-catch-within-finally": {
+		"category": "not_es3"
+	},
+	"built-ins/GeneratorPrototype/throw/try-finally-nested-try-catch-within-inner-try": {
+		"category": "not_es3"
+	},
+	"built-ins/GeneratorPrototype/throw/try-finally-nested-try-catch-within-outer-try-after-nested": {
+		"category": "not_es3"
+	},
+	"built-ins/GeneratorPrototype/throw/try-finally-nested-try-catch-within-outer-try-before-nested": {
+		"category": "not_es3"
+	},
+	"built-ins/GeneratorPrototype/throw/try-finally-within-finally": {
+		"category": "not_es3"
+	},
+	"built-ins/GeneratorPrototype/throw/try-finally-within-try": {
+		"category": "not_es3"
+	},
+	"built-ins/IteratorPrototype/Symbol.iterator/length": {
+		"category": "not_es3"
+	},
+	"built-ins/IteratorPrototype/Symbol.iterator/name": {
+		"category": "not_es3"
+	},
+	"built-ins/IteratorPrototype/Symbol.iterator/prop-desc": {
+		"category": "not_es3"
+	},
+	"built-ins/IteratorPrototype/Symbol.iterator/return-val": {
+		"category": "not_es3"
+	},
+	"built-ins/JSON/Symbol.toStringTag": {
+		"category": "not_es3"
+	},
+	"built-ins/JSON/parse/15.12.2-0-3": {
+		"category": "not_es3"
+	},
+	"built-ins/JSON/parse/name": {
+		"category": "not_es3"
+	},
+	"built-ins/JSON/stringify/15.12.3-0-3": {
+		"category": "not_es3"
+	},
+	"built-ins/JSON/stringify/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/Symbol.species/length": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/Symbol.species/symbol-species": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/Symbol.species/symbol-species-name": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/constructor": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/does-not-throw-when-set-is-not-callable": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/get-set-method-failure": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/iterable-calls-set": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/iterator-close-after-set-failure": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/iterator-item-first-entry-returns-abrupt": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/iterator-item-second-entry-returns-abrupt": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/iterator-items-are-not-object": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/iterator-items-are-not-object-close-iterator": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/iterator-next-failure": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/iterator-value-failure": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/length": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/map": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/map-iterable": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/map-iterable-empty-does-not-call-set": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/map-iterable-throws-when-set-is-not-callable": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/map-no-iterable": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/map-no-iterable-does-not-call-set": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/newtarget": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/properties-of-map-instances": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/properties-of-the-map-prototype-object": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype-of-map": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/Symbol.iterator": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/Symbol.toStringTag": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/clear/clear": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/clear/clear-map": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/clear/context-is-not-map-object": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/clear/context-is-not-object": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/clear/context-is-set-object-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/clear/context-is-weakmap-object-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/clear/length": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/clear/map-data-list-is-preserved": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/clear/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/clear/returns-undefined": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/constructor": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/delete/context-is-not-map-object": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/delete/context-is-not-object": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/delete/context-is-set-object-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/delete/context-is-weakmap-object-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/delete/delete": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/delete/does-not-break-iterators": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/delete/length": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/delete/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/delete/returns-false": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/delete/returns-true-for-deleted-entry": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/descriptor": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/entries/does-not-have-mapdata-internal-slot": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/entries/does-not-have-mapdata-internal-slot-set": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/entries/does-not-have-mapdata-internal-slot-weakmap": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/entries/entries": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/entries/length": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/entries/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/entries/returns-iterator": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/entries/returns-iterator-empty": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/entries/this-not-object-throw": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/forEach/callback-parameters": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/forEach/callback-result-is-abrupt": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/forEach/callback-this-non-strict": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/forEach/deleted-values-during-foreach": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/forEach/does-not-have-mapdata-internal-slot": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/forEach/does-not-have-mapdata-internal-slot-set": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/forEach/does-not-have-mapdata-internal-slot-weakmap": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/forEach/first-argument-is-not-callable": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/forEach/forEach": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/forEach/iterates-in-key-insertion-order": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/forEach/iterates-values-added-after-foreach-begins": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/forEach/iterates-values-deleted-then-readded": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/forEach/length": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/forEach/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/forEach/return-undefined": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/forEach/second-parameter-as-callback-context": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/forEach/this-not-object-throw": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/get/does-not-have-mapdata-internal-slot": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/get/does-not-have-mapdata-internal-slot-set": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/get/does-not-have-mapdata-internal-slot-weakmap": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/get/get": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/get/length": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/get/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/get/returns-undefined": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/get/returns-value-different-key-types": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/get/returns-value-normalized-zero-key": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/get/this-not-object-throw": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/has/does-not-have-mapdata-internal-slot": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/has/does-not-have-mapdata-internal-slot-set": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/has/does-not-have-mapdata-internal-slot-weakmap": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/has/has": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/has/length": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/has/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/has/normalizes-zero-key": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/has/return-false-different-key-types": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/has/return-true-different-key-types": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/has/this-not-object-throw": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/keys/does-not-have-mapdata-internal-slot": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/keys/does-not-have-mapdata-internal-slot-set": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/keys/does-not-have-mapdata-internal-slot-weakmap": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/keys/keys": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/keys/length": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/keys/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/keys/returns-iterator": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/keys/returns-iterator-empty": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/keys/this-not-object-throw": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/set/append-new-values": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/set/append-new-values-normalizes-zero-key": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/set/append-new-values-return-map": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/set/does-not-have-mapdata-internal-slot": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/set/does-not-have-mapdata-internal-slot-set": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/set/does-not-have-mapdata-internal-slot-weakmap": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/set/length": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/set/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/set/replaces-a-value": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/set/replaces-a-value-normalizes-zero-key": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/set/replaces-a-value-returns-map": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/set/set": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/set/this-not-object-throw": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/size/does-not-have-mapdata-internal-slot": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/size/does-not-have-mapdata-internal-slot-set": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/size/does-not-have-mapdata-internal-slot-weakmap": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/size/length": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/size/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/size/returns-count-of-present-values-before-after-set-clear": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/size/returns-count-of-present-values-before-after-set-delete": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/size/returns-count-of-present-values-by-insertion": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/size/returns-count-of-present-values-by-iterable": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/size/size": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/size/this-not-object-throw": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/values/does-not-have-mapdata-internal-slot": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/values/does-not-have-mapdata-internal-slot-set": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/values/does-not-have-mapdata-internal-slot-weakmap": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/values/length": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/values/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/values/returns-iterator": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/values/returns-iterator-empty": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/values/this-not-object-throw": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/prototype/values/values": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/symbol-as-entry-key": {
+		"category": "not_es3"
+	},
+	"built-ins/Map/undefined-newtarget": {
+		"category": "not_es3"
+	},
+	"built-ins/MapIteratorPrototype/Symbol.toStringTag": {
+		"category": "not_es3"
+	},
+	"built-ins/Math/Symbol.toStringTag": {
 		"category": "not_es3"
 	},
 	"built-ins/Math/acosh/acosh-descriptor": {
@@ -5336,16 +7652,16 @@
 	"built-ins/Math/asinh/name": {
 		"category": "not_es3"
 	},
-	"built-ins/Math/atanh/atanh-specialVals": {
-		"category": "not_es3"
-	},
-	"built-ins/Math/atanh/name": {
-		"category": "not_es3"
-	},
 	"built-ins/Math/atanh/atanh-descriptor": {
 		"category": "not_es3"
 	},
 	"built-ins/Math/atanh/atanh-length": {
+		"category": "not_es3"
+	},
+	"built-ins/Math/atanh/atanh-specialVals": {
+		"category": "not_es3"
+	},
+	"built-ins/Math/atanh/name": {
 		"category": "not_es3"
 	},
 	"built-ins/Math/cbrt/cbrt-descriptor": {
@@ -5489,6 +7805,78 @@
 	"built-ins/Math/log2/name": {
 		"category": "not_es3"
 	},
+	"built-ins/Math/sign/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Math/sign/sign-descriptor": {
+		"category": "not_es3"
+	},
+	"built-ins/Math/sign/sign-length": {
+		"category": "not_es3"
+	},
+	"built-ins/Math/sign/sign-specialVals": {
+		"category": "not_es3"
+	},
+	"built-ins/Math/sinh/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Math/sinh/sinh-descriptor": {
+		"category": "not_es3"
+	},
+	"built-ins/Math/sinh/sinh-length": {
+		"category": "not_es3"
+	},
+	"built-ins/Math/sinh/sinh-specialVals": {
+		"category": "not_es3"
+	},
+	"built-ins/Math/tanh/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Math/tanh/tanh-descriptor": {
+		"category": "not_es3"
+	},
+	"built-ins/Math/tanh/tanh-length": {
+		"category": "not_es3"
+	},
+	"built-ins/Math/tanh/tanh-specialVals": {
+		"category": "not_es3"
+	},
+	"built-ins/Math/trunc/Math.trunc_Infinity": {
+		"category": "not_es3"
+	},
+	"built-ins/Math/trunc/Math.trunc_NaN": {
+		"category": "not_es3"
+	},
+	"built-ins/Math/trunc/Math.trunc_NegDecimal": {
+		"category": "not_es3"
+	},
+	"built-ins/Math/trunc/Math.trunc_PosDecimal": {
+		"category": "not_es3"
+	},
+	"built-ins/Math/trunc/Math.trunc_Success": {
+		"category": "not_es3"
+	},
+	"built-ins/Math/trunc/Math.trunc_Zero": {
+		"category": "not_es3"
+	},
+	"built-ins/Math/trunc/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Math/trunc/trunc-descriptor": {
+		"category": "not_es3"
+	},
+	"built-ins/Math/trunc/trunc-length": {
+		"category": "not_es3"
+	},
+	"built-ins/Math/trunc/trunc-sampleTests": {
+		"category": "not_es3"
+	},
+	"built-ins/Math/trunc/trunc-specialVals": {
+		"category": "not_es3"
+	},
+	"built-ins/NativeErrors/EvalError/prototype/not-error-object": {
+		"category": "not_es3"
+	},
 	"built-ins/NativeErrors/RangeError/proto": {
 		"category": "not_es3"
 	},
@@ -5501,520 +7889,11116 @@
 	"built-ins/NativeErrors/ReferenceError/prototype/not-error-object": {
 		"category": "not_es3"
 	},
+	"built-ins/NativeErrors/SyntaxError/proto": {
+		"category": "not_es3"
+	},
 	"built-ins/NativeErrors/SyntaxError/prototype/not-error-object": {
-		"category": "not_es3"
-	},
-	"built-ins/NativeErrors/TypeError/prototype/not-error-object": {
-		"category": "not_es3"
-	},
-	"built-ins/NativeErrors/URIError/prototype/not-error-object": {
-		"category": "not_es3"
-	},
-	"built-ins/NativeErrors/URIError/proto": {
 		"category": "not_es3"
 	},
 	"built-ins/NativeErrors/TypeError/proto": {
 		"category": "not_es3"
 	},
-	"built-ins/NativeErrors/SyntaxError/proto": {
+	"built-ins/NativeErrors/TypeError/prototype/not-error-object": {
 		"category": "not_es3"
 	},
-	"built-ins/NativeErrors/EvalError/prototype/not-error-object": {
+	"built-ins/NativeErrors/URIError/proto": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/prototype/Symbol.toStringTag": {
+	"built-ins/NativeErrors/URIError/prototype/not-error-object": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/prototype/constructor": {
+	"built-ins/Number/isFinite/length": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/prototype/prototype-attributes": {
+	"built-ins/Number/isFinite/name": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/prototype/delete/delete-entry-initial-iterable": {
+	"built-ins/Number/isInteger/Number.isInteger_Double": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/constructor": {
+	"built-ins/Number/isInteger/Number.isInteger_Infinity": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/empty-iterable": {
+	"built-ins/Number/isInteger/Number.isInteger_NaN": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/get-set-method-failure": {
+	"built-ins/Number/isInteger/Number.isInteger_NonNumber": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/iterable-failure": {
+	"built-ins/Number/isInteger/Number.isInteger_String": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/iterable": {
+	"built-ins/Number/isInteger/Number.isInteger_Success": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/iterator-close-after-set-failure": {
+	"built-ins/Number/isInteger/length": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/iterator-item-first-entry-returns-abrupt": {
+	"built-ins/Number/isInteger/name": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/iterator-item-second-entry-returns-abrupt": {
+	"built-ins/Number/isNaN/Number.isNaN_Boolean": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/iterator-items-are-not-object-close-iterator": {
+	"built-ins/Number/isNaN/Number.isNaN_NaN": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/iterator-items-are-not-object": {
+	"built-ins/Number/isNaN/Number.isNaN_Object": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/iterator-next-failure": {
+	"built-ins/Number/isNaN/Number.isNaN_String": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/iterator-value-failure": {
+	"built-ins/Number/isNaN/length": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/length": {
+	"built-ins/Number/isNaN/name": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/name": {
+	"built-ins/Number/isSafeInteger/length": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/no-iterable": {
+	"built-ins/Number/isSafeInteger/name": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/properties-of-map-instances": {
+	"built-ins/Object/assign/ObjectOverride-sameproperty": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/properties-of-the-weakmap-prototype-object": {
+	"built-ins/Object/assign/OnlyOneArgument": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/prototype-of-weakmap": {
+	"built-ins/Object/assign/Override": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/set-not-callable-throws": {
+	"built-ins/Object/assign/Override-notstringtarget": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/undefined-newtarget": {
+	"built-ins/Object/assign/Source-Null-Undefined": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/weakmap": {
+	"built-ins/Object/assign/Source-Number-Boolen-Symbol": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/prototype/delete/delete-entry": {
+	"built-ins/Object/assign/Source-String": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/prototype/delete/delete": {
+	"built-ins/Object/assign/Target-Boolean": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/prototype/delete/does-not-have-weakmapdata-internal-slot-array": {
+	"built-ins/Object/assign/Target-Number": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/prototype/delete/does-not-have-weakmapdata-internal-slot-map": {
+	"built-ins/Object/assign/Target-Object": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/prototype/delete/does-not-have-weakmapdata-internal-slot-object": {
+	"built-ins/Object/assign/Target-String": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/prototype/delete/does-not-have-weakmapdata-internal-slot-set": {
+	"built-ins/Object/assign/Target-Symbol": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/prototype/delete/does-not-have-weakmapdata-internal-slot-weakmap-prototype": {
+	"built-ins/Object/assign/assign-descriptor": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/prototype/delete/length": {
+	"built-ins/Object/assign/assign-length": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/prototype/delete/name": {
+	"built-ins/Object/assign/name": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/prototype/delete/returns-false-value-is-not-object": {
+	"built-ins/Object/assign/source-get-attr-error": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/prototype/delete/returns-false-when-delete-is-noop": {
+	"built-ins/Object/assign/source-non-enum": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/prototype/delete/this-not-object-throw-boolean": {
+	"built-ins/Object/assign/source-own-prop-desc-missing": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/prototype/delete/this-not-object-throw-null": {
+	"built-ins/Object/assign/source-own-prop-error": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/prototype/delete/this-not-object-throw-number": {
+	"built-ins/Object/assign/source-own-prop-keys-error": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/prototype/delete/this-not-object-throw-string": {
+	"built-ins/Object/assign/target-set-user-error": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/prototype/delete/this-not-object-throw-symbol": {
+	"built-ins/Object/create/15.2.3.5-0-1": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/prototype/delete/this-not-object-throw-undefined": {
+	"built-ins/Object/create/15.2.3.5-0-2": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/prototype/get/does-not-have-weakmapdata-internal-slot-map": {
+	"built-ins/Object/create/15.2.3.5-1-2": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/prototype/get/does-not-have-weakmapdata-internal-slot-set": {
+	"built-ins/Object/create/15.2.3.5-2-1": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/prototype/get/does-not-have-weakmapdata-internal-slot": {
+	"built-ins/Object/create/15.2.3.5-2-2": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/prototype/get/get": {
+	"built-ins/Object/create/15.2.3.5-3-1": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/prototype/get/length": {
+	"built-ins/Object/create/15.2.3.5-4-1": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/prototype/get/name": {
+	"built-ins/Object/create/15.2.3.5-4-10": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/prototype/get/returns-undefined-key-is-not-object": {
+	"built-ins/Object/create/15.2.3.5-4-100": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/prototype/get/returns-undefined": {
+	"built-ins/Object/create/15.2.3.5-4-101": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/prototype/get/returns-value": {
+	"built-ins/Object/create/15.2.3.5-4-102": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/prototype/get/this-not-object-throw": {
+	"built-ins/Object/create/15.2.3.5-4-103": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/prototype/has/does-not-have-weakmapdata-internal-slot-array": {
+	"built-ins/Object/create/15.2.3.5-4-104": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/prototype/has/does-not-have-weakmapdata-internal-slot-map": {
+	"built-ins/Object/create/15.2.3.5-4-105": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/prototype/has/does-not-have-weakmapdata-internal-slot-object": {
+	"built-ins/Object/create/15.2.3.5-4-106": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/prototype/has/does-not-have-weakmapdata-internal-slot-set": {
+	"built-ins/Object/create/15.2.3.5-4-107": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/prototype/has/does-not-have-weakmapdata-internal-slot-weakmap-prototype": {
+	"built-ins/Object/create/15.2.3.5-4-108": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/prototype/has/has": {
+	"built-ins/Object/create/15.2.3.5-4-109": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/prototype/has/length": {
+	"built-ins/Object/create/15.2.3.5-4-11": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/prototype/has/name": {
+	"built-ins/Object/create/15.2.3.5-4-110": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/prototype/has/returns-false-when-value-is-not-object": {
+	"built-ins/Object/create/15.2.3.5-4-111": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/prototype/has/returns-false-when-value-not-present": {
+	"built-ins/Object/create/15.2.3.5-4-112": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/prototype/has/returns-true-when-value-present": {
+	"built-ins/Object/create/15.2.3.5-4-113": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/prototype/has/this-not-object-throw-boolean": {
+	"built-ins/Object/create/15.2.3.5-4-114": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/prototype/has/this-not-object-throw-null": {
+	"built-ins/Object/create/15.2.3.5-4-115": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/prototype/has/this-not-object-throw-number": {
+	"built-ins/Object/create/15.2.3.5-4-116": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/prototype/has/this-not-object-throw-string": {
+	"built-ins/Object/create/15.2.3.5-4-117": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/prototype/has/this-not-object-throw-symbol": {
+	"built-ins/Object/create/15.2.3.5-4-118": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/prototype/has/this-not-object-throw-undefined": {
+	"built-ins/Object/create/15.2.3.5-4-119": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/prototype/set/adds-element": {
+	"built-ins/Object/create/15.2.3.5-4-12": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/prototype/set/does-not-have-weakmapdata-internal-slot-array": {
+	"built-ins/Object/create/15.2.3.5-4-120": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/prototype/set/does-not-have-weakmapdata-internal-slot-map": {
+	"built-ins/Object/create/15.2.3.5-4-121": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/prototype/set/does-not-have-weakmapdata-internal-slot-object": {
+	"built-ins/Object/create/15.2.3.5-4-122": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/prototype/set/does-not-have-weakmapdata-internal-slot-set": {
+	"built-ins/Object/create/15.2.3.5-4-124": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/prototype/set/does-not-have-weakmapdata-internal-slot-weakmap-prototype": {
+	"built-ins/Object/create/15.2.3.5-4-125": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/prototype/set/key-not-object-throw": {
+	"built-ins/Object/create/15.2.3.5-4-126": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/prototype/set/length": {
+	"built-ins/Object/create/15.2.3.5-4-127": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/prototype/set/name": {
+	"built-ins/Object/create/15.2.3.5-4-128": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/prototype/set/returns-this-when-ignoring-duplicate": {
+	"built-ins/Object/create/15.2.3.5-4-129": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/prototype/set/returns-this": {
+	"built-ins/Object/create/15.2.3.5-4-13": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/prototype/set/set": {
+	"built-ins/Object/create/15.2.3.5-4-130": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/prototype/set/this-not-object-throw-boolean": {
+	"built-ins/Object/create/15.2.3.5-4-131": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/prototype/set/this-not-object-throw-null": {
+	"built-ins/Object/create/15.2.3.5-4-132": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/prototype/set/this-not-object-throw-number": {
+	"built-ins/Object/create/15.2.3.5-4-133": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/prototype/set/this-not-object-throw-string": {
+	"built-ins/Object/create/15.2.3.5-4-134": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/prototype/set/this-not-object-throw-symbol": {
+	"built-ins/Object/create/15.2.3.5-4-135": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakMap/prototype/set/this-not-object-throw-undefined": {
+	"built-ins/Object/create/15.2.3.5-4-136": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/add-not-callable-throws": {
+	"built-ins/Object/create/15.2.3.5-4-137": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/constructor": {
+	"built-ins/Object/create/15.2.3.5-4-138": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/empty-iterable": {
+	"built-ins/Object/create/15.2.3.5-4-139": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/get-add-method-failure": {
+	"built-ins/Object/create/15.2.3.5-4-14": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/iterable-failure": {
+	"built-ins/Object/create/15.2.3.5-4-140": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/iterable": {
+	"built-ins/Object/create/15.2.3.5-4-141": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/iterator-close-after-add-failure": {
+	"built-ins/Object/create/15.2.3.5-4-142": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/iterator-next-failure": {
+	"built-ins/Object/create/15.2.3.5-4-143": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/iterator-value-failure": {
+	"built-ins/Object/create/15.2.3.5-4-144": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/length": {
+	"built-ins/Object/create/15.2.3.5-4-145": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/name": {
+	"built-ins/Object/create/15.2.3.5-4-146": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/no-iterable": {
+	"built-ins/Object/create/15.2.3.5-4-147": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/properties-of-the-weakset-prototype-object": {
+	"built-ins/Object/create/15.2.3.5-4-149": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/prototype-of-weakset": {
+	"built-ins/Object/create/15.2.3.5-4-15": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/symbol-disallowed-as-weakset-key": {
+	"built-ins/Object/create/15.2.3.5-4-150": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/undefined-newtarget": {
+	"built-ins/Object/create/15.2.3.5-4-151": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/weakset": {
+	"built-ins/Object/create/15.2.3.5-4-152": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/prototype/Symbol.toStringTag": {
+	"built-ins/Object/create/15.2.3.5-4-153": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/prototype/prototype-attributes": {
+	"built-ins/Object/create/15.2.3.5-4-154": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/prototype/add/add": {
+	"built-ins/Object/create/15.2.3.5-4-155": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/prototype/add/adds-element": {
+	"built-ins/Object/create/15.2.3.5-4-156": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/prototype/add/does-not-have-weaksetdata-internal-slot-array": {
+	"built-ins/Object/create/15.2.3.5-4-157": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/prototype/add/does-not-have-weaksetdata-internal-slot-map": {
+	"built-ins/Object/create/15.2.3.5-4-158": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/prototype/add/does-not-have-weaksetdata-internal-slot-object": {
+	"built-ins/Object/create/15.2.3.5-4-159": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/prototype/add/does-not-have-weaksetdata-internal-slot-set": {
+	"built-ins/Object/create/15.2.3.5-4-16": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/prototype/add/does-not-have-weaksetdata-internal-slot-weakset-prototype": {
+	"built-ins/Object/create/15.2.3.5-4-160": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/prototype/add/length": {
+	"built-ins/Object/create/15.2.3.5-4-161": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/prototype/add/name": {
+	"built-ins/Object/create/15.2.3.5-4-162": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/prototype/add/returns-this-when-ignoring-duplicate": {
+	"built-ins/Object/create/15.2.3.5-4-163": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/prototype/add/returns-this": {
+	"built-ins/Object/create/15.2.3.5-4-164": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/prototype/add/this-not-object-throw-boolean": {
+	"built-ins/Object/create/15.2.3.5-4-165": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/prototype/add/this-not-object-throw-null": {
+	"built-ins/Object/create/15.2.3.5-4-166": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/prototype/add/this-not-object-throw-number": {
+	"built-ins/Object/create/15.2.3.5-4-167": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/prototype/add/this-not-object-throw-string": {
+	"built-ins/Object/create/15.2.3.5-4-168": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/prototype/add/this-not-object-throw-symbol": {
+	"built-ins/Object/create/15.2.3.5-4-169": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/prototype/add/this-not-object-throw-undefined": {
+	"built-ins/Object/create/15.2.3.5-4-17": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/prototype/add/value-not-object-throw": {
+	"built-ins/Object/create/15.2.3.5-4-170": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/prototype/constructor/weakset-prototype-constructor-intrinsic": {
+	"built-ins/Object/create/15.2.3.5-4-171": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/prototype/constructor/weakset-prototype-constructor": {
+	"built-ins/Object/create/15.2.3.5-4-172": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/prototype/delete/delete-entry-initial-iterable": {
+	"built-ins/Object/create/15.2.3.5-4-173": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/prototype/delete/delete-entry": {
+	"built-ins/Object/create/15.2.3.5-4-174": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/prototype/delete/delete": {
+	"built-ins/Object/create/15.2.3.5-4-175": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/prototype/delete/does-not-have-weaksetdata-internal-slot-array": {
+	"built-ins/Object/create/15.2.3.5-4-177": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/prototype/delete/does-not-have-weaksetdata-internal-slot-map": {
+	"built-ins/Object/create/15.2.3.5-4-178": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/prototype/delete/does-not-have-weaksetdata-internal-slot-object": {
+	"built-ins/Object/create/15.2.3.5-4-179": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/prototype/delete/does-not-have-weaksetdata-internal-slot-set": {
+	"built-ins/Object/create/15.2.3.5-4-18": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/prototype/delete/does-not-have-weaksetdata-internal-slot-weakset-prototype": {
+	"built-ins/Object/create/15.2.3.5-4-180": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/prototype/delete/length": {
+	"built-ins/Object/create/15.2.3.5-4-181": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/prototype/delete/name": {
+	"built-ins/Object/create/15.2.3.5-4-182": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/prototype/delete/returns-false-value-is-not-object": {
+	"built-ins/Object/create/15.2.3.5-4-183": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/prototype/delete/returns-false-when-delete-is-noop": {
+	"built-ins/Object/create/15.2.3.5-4-184": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/prototype/delete/this-not-object-throw-boolean": {
+	"built-ins/Object/create/15.2.3.5-4-185": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/prototype/delete/this-not-object-throw-null": {
+	"built-ins/Object/create/15.2.3.5-4-186": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/prototype/delete/this-not-object-throw-number": {
+	"built-ins/Object/create/15.2.3.5-4-187": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/prototype/delete/this-not-object-throw-string": {
+	"built-ins/Object/create/15.2.3.5-4-188": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/prototype/delete/this-not-object-throw-symbol": {
+	"built-ins/Object/create/15.2.3.5-4-189": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/prototype/delete/this-not-object-throw-undefined": {
+	"built-ins/Object/create/15.2.3.5-4-19": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/prototype/has/does-not-have-weaksetdata-internal-slot-array": {
+	"built-ins/Object/create/15.2.3.5-4-190": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/prototype/has/does-not-have-weaksetdata-internal-slot-map": {
+	"built-ins/Object/create/15.2.3.5-4-191": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/prototype/has/does-not-have-weaksetdata-internal-slot-object": {
+	"built-ins/Object/create/15.2.3.5-4-192": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/prototype/has/does-not-have-weaksetdata-internal-slot-set": {
+	"built-ins/Object/create/15.2.3.5-4-193": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/prototype/has/does-not-have-weaksetdata-internal-slot-weakset-prototype": {
+	"built-ins/Object/create/15.2.3.5-4-194": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/prototype/has/has": {
+	"built-ins/Object/create/15.2.3.5-4-195": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/prototype/has/length": {
+	"built-ins/Object/create/15.2.3.5-4-196": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/prototype/has/name": {
+	"built-ins/Object/create/15.2.3.5-4-197": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/prototype/has/returns-false-when-value-is-not-object": {
+	"built-ins/Object/create/15.2.3.5-4-198": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/prototype/has/returns-false-when-value-not-present": {
+	"built-ins/Object/create/15.2.3.5-4-199": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/prototype/has/returns-true-when-value-present": {
+	"built-ins/Object/create/15.2.3.5-4-2": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/prototype/has/this-not-object-throw-boolean": {
+	"built-ins/Object/create/15.2.3.5-4-20": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/prototype/has/this-not-object-throw-null": {
+	"built-ins/Object/create/15.2.3.5-4-200": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/prototype/has/this-not-object-throw-number": {
+	"built-ins/Object/create/15.2.3.5-4-201": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/prototype/has/this-not-object-throw-string": {
+	"built-ins/Object/create/15.2.3.5-4-203": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/prototype/has/this-not-object-throw-symbol": {
+	"built-ins/Object/create/15.2.3.5-4-204": {
 		"category": "not_es3"
 	},
-	"built-ins/WeakSet/prototype/has/this-not-object-throw-undefined": {
+	"built-ins/Object/create/15.2.3.5-4-205": {
 		"category": "not_es3"
 	},
-	"built-ins/TypedArray/invoked": {
+	"built-ins/Object/create/15.2.3.5-4-206": {
 		"category": "not_es3"
 	},
-	"built-ins/TypedArray/length": {
+	"built-ins/Object/create/15.2.3.5-4-207": {
 		"category": "not_es3"
 	},
-	"built-ins/TypedArray/name": {
+	"built-ins/Object/create/15.2.3.5-4-208": {
 		"category": "not_es3"
 	},
-	"built-ins/TypedArray/prototype": {
+	"built-ins/Object/create/15.2.3.5-4-209": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-21": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-210": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-211": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-212": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-213": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-214": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-215": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-216": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-217": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-218": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-219": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-22": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-220": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-221": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-222": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-223": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-224": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-225": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-226": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-228": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-229": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-23": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-230": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-231": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-232": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-233": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-234": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-235": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-236": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-237": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-238": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-239": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-24": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-240": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-241": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-242": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-243": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-244": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-245": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-246": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-247": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-248": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-249": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-25": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-250": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-251": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-252": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-253": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-254": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-256": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-257": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-263": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-266": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-267": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-268": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-269": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-270": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-271": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-272": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-273": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-274": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-275": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-276": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-277": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-278": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-279": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-28": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-280": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-281": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-282": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-283": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-284": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-285": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-286": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-287": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-288": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-289": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-29": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-291": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-292": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-298": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-30": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-305": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-306": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-307": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-308": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-309": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-31": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-310": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-311": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-312": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-313": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-314": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-315": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-316": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-32": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-33": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-34": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-35": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-36": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-37": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-38": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-39": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-40": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-46": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-47": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-48": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-49": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-50": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-51": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-52": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-53": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-54": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-55": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-56": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-57": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-58": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-59": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-60": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-61": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-62": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-63": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-64": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-65": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-66": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-67": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-68": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-69": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-71": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-72": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-73": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-74": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-75": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-76": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-77": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-78": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-79": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-80": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-81": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-82": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-83": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-84": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-85": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-86": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-87": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-88": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-89": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-90": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-91": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-92": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-93": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-94": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-96": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-97": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-98": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/15.2.3.5-4-99": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/create/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-0-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-0-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-2-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-2-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-2-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-2-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-2-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-2-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-2-16": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-2-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-2-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-2-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-2-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-2-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-2-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-2-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-3-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-3-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-3-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-3-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-3-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-3-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-3-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-3-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-a-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-a-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-a-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-a-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-a-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-a-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-a-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-a-16": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-a-17": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-a-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-a-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-a-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-a-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-a-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-a-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-a-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-a-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-100": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-101": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-102": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-103": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-104": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-105": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-106": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-107": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-109": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-110": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-111": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-112": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-113": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-114": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-115": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-116": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-117": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-118": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-119": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-120": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-121": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-122": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-123": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-124": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-125": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-126": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-127": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-128": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-129": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-130": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-131": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-132": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-133": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-134": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-135": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-137": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-138": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-139": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-140": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-141": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-142": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-143": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-144": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-145": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-146": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-147": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-148": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-149": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-150": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-151": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-152": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-153": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-154": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-155": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-156": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-157": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-158": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-159": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-16": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-160": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-161": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-163": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-164": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-165": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-166": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-167": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-168": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-169": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-17": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-170": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-171": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-172": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-173": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-174": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-175": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-176": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-177": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-178": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-179": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-18": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-180": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-181": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-182": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-183": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-184": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-185": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-186": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-188": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-189": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-19": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-190": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-191": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-192": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-193": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-194": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-195": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-196": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-197": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-198": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-199": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-20": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-200": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-201": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-202": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-203": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-204": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-205": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-206": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-207": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-208": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-209": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-21": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-210": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-211": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-212": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-213": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-214": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-216": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-217": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-22": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-223": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-226": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-227": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-228": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-229": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-23": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-230": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-231": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-232": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-233": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-234": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-235": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-236": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-237": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-238": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-239": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-24": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-240": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-241": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-242": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-243": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-244": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-245": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-246": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-247": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-248": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-249": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-25": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-252": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-258": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-26": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-27": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-28": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-29": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-31": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-32": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-33": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-34": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-35": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-36": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-37": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-38": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-39": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-40": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-41": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-42": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-43": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-44": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-45": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-46": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-47": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-48": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-49": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-50": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-51": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-52": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-53": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-54": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-56": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-57": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-58": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-59": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-60": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-61": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-62": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-63": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-64": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-65": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-66": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-67": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-68": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-69": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-70": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-71": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-72": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-73": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-74": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-75": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-76": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-77": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-78": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-79": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-80": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-81": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-82": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-84": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-85": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-86": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-87": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-88": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-89": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-90": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-91": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-92": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-93": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-94": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-95": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-96": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-97": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-98": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-5-b-99": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-100": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-101": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-102": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-103": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-104": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-105": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-106": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-107": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-108": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-109": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-110": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-111": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-112": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-113": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-114": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-114-b": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-115": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-119": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-120": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-121": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-122": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-123": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-124": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-125": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-126": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-127": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-128": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-129": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-130": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-131": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-132": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-133": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-134": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-135": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-136": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-137": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-138": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-139": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-140": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-141": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-142": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-143": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-144": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-145": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-146": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-147": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-148": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-149": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-150": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-151": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-152": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-153": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-155": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-156": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-157": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-158": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-159": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-16": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-160": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-161": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-162": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-163": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-164": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-165": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-166": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-167": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-168": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-169": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-17": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-170": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-171": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-172": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-173": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-174": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-175": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-176": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-177": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-178": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-179": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-18": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-180": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-181": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-182": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-183": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-184": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-185": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-187": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-189": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-19": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-190": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-191": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-192": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-193": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-194": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-195": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-196": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-197": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-198": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-199": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-20": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-200": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-201": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-202": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-203": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-204": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-205": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-206": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-207": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-208": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-209": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-21": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-210": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-211": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-212": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-213": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-214": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-215": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-216": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-217": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-218": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-219": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-220": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-221": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-222": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-223": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-224": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-225": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-226": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-227": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-228": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-229": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-230": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-231": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-232": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-233": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-234": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-235": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-236": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-237": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-238": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-239": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-24": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-240": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-241": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-242": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-243": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-244": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-245": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-246": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-247": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-248": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-249": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-25": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-250": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-251": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-252": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-253": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-254": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-255": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-256": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-257": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-258": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-259": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-26": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-260": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-261": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-262": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-263": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-264": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-265": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-266": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-267": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-268": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-269": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-27": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-270": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-271": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-272": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-273": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-274": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-275": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-276": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-277": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-278": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-279": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-28": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-280": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-281": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-282": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-283": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-284": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-285": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-286": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-287": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-288": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-289": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-29": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-290": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-291": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-292": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-293": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-294": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-295": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-296": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-297": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-298": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-299": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-30": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-300": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-301": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-302": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-303": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-304": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-305": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-306": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-307": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-308": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-309": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-31": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-310": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-311": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-312": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-313": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-314": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-32": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-33": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-34": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-35": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-36": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-37": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-38": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-38-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-39": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-40": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-41": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-42": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-43": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-44": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-45": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-46": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-47": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-48": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-49": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-50": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-51": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-52": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-53": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-54": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-55": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-56": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-57": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-58": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-59": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-60": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-61": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-62": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-63": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-64": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-65": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-66": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-66-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-67": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-68": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-69": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-70": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-71": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-72": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-73": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-74": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-75": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-76": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-77": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-78": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-79": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-80": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-81": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-82": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-83": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-84": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-84-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-85": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-86": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-86-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-87": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-88": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-89": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-90": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-91": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-92": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-93": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-93-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-93-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-93-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-93-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-94": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-95": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-96": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-97": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-98": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/15.2.3.7-6-a-99": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperties/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-1-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-1-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-1-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-1-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-100": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-102": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-103": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-104": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-105": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-106": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-109": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-132": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-133": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-134": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-135": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-152": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-153": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-158": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-159": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-160": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-161": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-162": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-163": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-164": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-17": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-171-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-178": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-179": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-18": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-181": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-182": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-183": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-184": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-185": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-188": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-19": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-205": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-207": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-208": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-209": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-210": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-211": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-212": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-213": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-214": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-218": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-218-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-219": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-219-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-220": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-220-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-221": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-221-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-222": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-222-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-223": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-223-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-224": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-224-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-225": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-225-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-226": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-226-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-227": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-227-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-228": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-228-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-230": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-232": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-235": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-236": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-237": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-238": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-239": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-240": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-241": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-242": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-243": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-244": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-245": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-246": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-247": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-248": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-248-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-249": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-249-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-250": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-250-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-251": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-251-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-252": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-252-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-253": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-253-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-254": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-254-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-255": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-255-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-256": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-256-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-257": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-257-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-258": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-258-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-26": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-260": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-261": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-262": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-27": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-28": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-29": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-73": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-74": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-76": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-79": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-80": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-81": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-82": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-83": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-84": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-85": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-3-99": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-100": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-101": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-102": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-103": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-104": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-105": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-106": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-107": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-108": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-109": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-110": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-111": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-112": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-113": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-114": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-115": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-116": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-117": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-118": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-119": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-120": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-121": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-122": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-123": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-124": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-126": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-142": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-143": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-144": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-146": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-147": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-148": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-149": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-150": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-151": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-16": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-162": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-163": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-164": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-167": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-168": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-169": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-17": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-170": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-172": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-173": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-174": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-176": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-177": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-18": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-181": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-183": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-187": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-188": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-189": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-19": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-190": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-192": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-193": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-194": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-195": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-196": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-197": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-198": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-199": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-20": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-200": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-201": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-202": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-203": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-204": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-205": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-206": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-207": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-208": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-209": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-21": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-210": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-211": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-212": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-213": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-214": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-215": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-216": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-217": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-218": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-219": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-22": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-220": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-221": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-222": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-223": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-224": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-225": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-226": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-227": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-228": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-229": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-230": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-231": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-232": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-233": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-234": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-235": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-236": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-237": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-238": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-239": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-24": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-240": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-241": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-242": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-242-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-243": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-243-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-244": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-245": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-246": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-247": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-248": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-249": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-25": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-250": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-251": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-252": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-253": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-254": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-255": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-256": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-257": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-258": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-259": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-26": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-260": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-261": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-262": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-263": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-264": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-265": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-266": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-267": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-268": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-269": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-27": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-270": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-271": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-272": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-273": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-275": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-276": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-277": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-278": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-279": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-28": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-280": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-281": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-282": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-283": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-284": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-285": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-286": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-287": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-288": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-289": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-289-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-29": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-290": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-290-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-291": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-291-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-292": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-292-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-293": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-293-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-293-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-293-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-294": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-294-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-295": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-295-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-296": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-296-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-297": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-297-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-298": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-298-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-299": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-299-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-30": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-300": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-300-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-301": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-301-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-302": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-302-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-303": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-304": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-305": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-306": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-307": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-308": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-309": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-31": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-310": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-311": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-312": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-313": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-313-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-314": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-314-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-315": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-315-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-316": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-316-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-317": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-317-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-318": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-318-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-319": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-319-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-320": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-320-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-321": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-321-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-322": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-322-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-323": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-323-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-324": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-324-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-325": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-325-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-327": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-329": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-33": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-330": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-331": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-332": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-333-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-333-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-333-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-333-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-333-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-333-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-333-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-334": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-335": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-336": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-337": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-338": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-339": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-339-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-339-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-339-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-339-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-34": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-341": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-343": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-344": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-345": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-346": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-348": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-349": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-35": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-350": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-351": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-352": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-353": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-354": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-354-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-354-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-354-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-354-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-354-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-354-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-354-16": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-354-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-354-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-354-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-354-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-354-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-354-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-355": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-357": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-358": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-359": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-36": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-360": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-360-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-360-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-360-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-360-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-360-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-360-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-361": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-362": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-363": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-364": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-365": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-366": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-367": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-368": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-369": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-37": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-371": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-372": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-373": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-374": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-375": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-376": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-377": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-378": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-379": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-38": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-380": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-381": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-382": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-383": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-384": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-385": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-386": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-387": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-388": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-389": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-39": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-390": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-391": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-392": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-393": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-394": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-395": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-396": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-397": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-398": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-399": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-40": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-41": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-412": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-413": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-414": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-415": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-416": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-417": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-418": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-419": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-42": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-420": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-421": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-422": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-423": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-424": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-425": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-426": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-427": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-428": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-429": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-43": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-430": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-431": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-432": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-433": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-434": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-435": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-436": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-437": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-438": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-439": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-440": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-441": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-442": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-443": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-444": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-445": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-446": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-447": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-448": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-449": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-45": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-450": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-451": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-452": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-453": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-454": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-455": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-456": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-457": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-458": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-459": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-460": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-461": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-462": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-463": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-464": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-465": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-466": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-467": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-468": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-469": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-47": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-470": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-471": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-472": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-473": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-474": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-475": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-476": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-477": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-478": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-479": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-48": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-480": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-481": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-482": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-483": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-484": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-485": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-486": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-487": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-488": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-489": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-49": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-490": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-491": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-492": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-493": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-494": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-495": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-496": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-497": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-498": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-499": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-50": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-500": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-501": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-502": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-503": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-504": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-505": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-506": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-507": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-508": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-509": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-51": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-510": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-511": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-512": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-513": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-514": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-515": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-516": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-517": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-518": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-519": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-52": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-520": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-521": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-522": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-523": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-524": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-525": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-526": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-527": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-528": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-529": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-53": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-530": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-531": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-531-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-531-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-531-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-531-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-531-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-531-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-531-16": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-531-17": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-531-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-531-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-531-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-531-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-531-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-531-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-532": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-533": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-534": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-535": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-536": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-537": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-538": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-538-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-538-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-538-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-538-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-538-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-538-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-539": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-54": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-540": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-540-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-540-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-540-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-540-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-541": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-542": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-543": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-544": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-545": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-546": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-547": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-547-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-547-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-547-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-547-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-548": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-549": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-55": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-550": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-551": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-552": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-553": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-554": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-555": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-556": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-557": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-558": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-559": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-56": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-560": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-561": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-562": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-563": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-564": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-565": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-566": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-567": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-568": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-569": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-57": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-570": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-571": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-572": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-573": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-574": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-575": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-576": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-577": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-578": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-579": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-58": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-581": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-583": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-584": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-586": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-588": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-589": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-59": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-590": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-591": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-592": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-593": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-594": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-595": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-596": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-597": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-598": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-599": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-60": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-600": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-601": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-602": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-603": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-604": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-605": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-606": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-607": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-608": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-609": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-61": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-610": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-611": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-612": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-613": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-614": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-615": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-616": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-617": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-618": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-619": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-62": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-620": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-621": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-622": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-623": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-624": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-63": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-64": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-65": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-66": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-67": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-68": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-69": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-70": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-71": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-72": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-73": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-74": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-75": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-76": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-77": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-78": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-79": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-80": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-81": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-82": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-82-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-82-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-82-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-82-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-82-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-82-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-82-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-82-16": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-82-17": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-82-18": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-82-19": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-82-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-82-20": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-82-21": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-82-22": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-82-23": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-82-24": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-82-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-82-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-82-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-82-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-82-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-82-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-82-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-83": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-84": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-85": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-86": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-87": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-88": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-89": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-90": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-91": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-92": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-93": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-94": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-95": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-96": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-97": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-98": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/15.2.3.6-4-99": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/8.12.9-9-b-i_1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/8.12.9-9-b-i_2": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/8.12.9-9-c-i_1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/8.12.9-9-c-i_2": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/S15.2.3.6_A2": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/symbol-data-property-configurable": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/symbol-data-property-default-non-strict": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/defineProperty/symbol-data-property-writable": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/entries/exception-during-enumeration": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/entries/function-length": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/entries/function-name": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/entries/function-property-descriptor": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/entries/getter-adding-key": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/entries/getter-making-future-key-nonenumerable": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/entries/getter-removing-future-key": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/entries/inherited-properties-omitted": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/entries/observable-operations": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/entries/primitive-booleans": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/entries/primitive-numbers": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/entries/primitive-strings": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/entries/primitive-symbols": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/entries/symbols-omitted": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/entries/tamper-with-global-object": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/entries/tamper-with-object-keys": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/freeze/15.2.3.9-0-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/freeze/15.2.3.9-0-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/freeze/15.2.3.9-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/freeze/15.2.3.9-1-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/freeze/15.2.3.9-1-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/freeze/15.2.3.9-1-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/freeze/15.2.3.9-1-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/freeze/15.2.3.9-2-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/freeze/15.2.3.9-2-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/freeze/15.2.3.9-2-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/freeze/15.2.3.9-2-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/freeze/15.2.3.9-2-a-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/freeze/15.2.3.9-2-a-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/freeze/15.2.3.9-2-a-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/freeze/15.2.3.9-2-a-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/freeze/15.2.3.9-2-a-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/freeze/15.2.3.9-2-a-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/freeze/15.2.3.9-2-a-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/freeze/15.2.3.9-2-a-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/freeze/15.2.3.9-2-a-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/freeze/15.2.3.9-2-a-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/freeze/15.2.3.9-2-a-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/freeze/15.2.3.9-2-a-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/freeze/15.2.3.9-2-a-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/freeze/15.2.3.9-2-a-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/freeze/15.2.3.9-2-b-i-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/freeze/15.2.3.9-2-b-i-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/freeze/15.2.3.9-2-c-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/freeze/15.2.3.9-2-c-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/freeze/15.2.3.9-2-c-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/freeze/15.2.3.9-2-c-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/freeze/15.2.3.9-2-d-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/freeze/15.2.3.9-2-d-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/freeze/15.2.3.9-2-d-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/freeze/15.2.3.9-2-d-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/freeze/15.2.3.9-2-d-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/freeze/15.2.3.9-2-d-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/freeze/15.2.3.9-2-d-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/freeze/15.2.3.9-2-d-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/freeze/15.2.3.9-2-d-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/freeze/15.2.3.9-3-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/freeze/15.2.3.9-4-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/freeze/15.2.3.9-4-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/freeze/15.2.3.9-4-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/freeze/frozen-object-contains-symbol-properties-non-strict": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/freeze/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-0-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-0-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-1-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-1-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-2-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-2-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-2-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-2-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-2-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-2-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-2-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-2-16": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-2-17": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-2-18": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-2-19": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-2-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-2-20": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-2-21": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-2-22": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-2-23": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-2-24": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-2-25": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-2-26": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-2-27": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-2-28": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-2-29": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-2-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-2-30": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-2-31": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-2-32": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-2-33": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-2-34": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-2-35": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-2-36": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-2-37": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-2-38": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-2-39": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-2-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-2-40": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-2-41": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-2-42": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-2-43": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-2-44": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-2-45": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-2-46": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-2-47": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-2-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-2-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-2-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-2-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-2-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-3-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-3-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-3-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-3-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-3-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-3-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-3-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-3-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-3-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-3-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-3-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-3-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-3-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-100": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-101": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-102": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-103": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-104": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-105": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-106": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-107": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-108": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-109": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-110": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-111": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-112": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-113": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-114": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-115": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-116": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-117": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-118": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-120": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-121": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-122": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-123": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-124": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-125": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-126": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-127": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-128": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-129": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-130": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-131": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-132": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-133": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-134": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-135": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-136": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-138": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-139": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-140": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-141": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-142": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-143": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-144": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-145": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-146": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-147": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-148": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-149": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-150": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-151": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-152": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-153": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-154": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-156": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-157": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-158": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-159": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-16": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-160": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-161": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-162": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-163": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-165": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-166": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-167": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-168": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-169": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-17": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-170": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-171": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-172": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-173": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-174": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-175": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-176": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-177": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-178": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-179": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-18": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-180": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-182": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-183": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-184": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-185": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-186": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-187": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-188": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-189": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-19": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-190": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-191": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-192": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-193": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-194": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-195": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-196": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-197": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-198": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-199": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-20": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-200": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-201": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-202": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-203": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-204": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-205": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-206": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-207": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-208": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-209": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-21": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-210": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-211": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-212": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-213": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-214": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-215": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-216": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-217": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-218": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-219": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-22": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-220": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-221": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-222": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-223": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-224": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-225": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-226": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-227": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-228": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-229": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-23": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-230": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-231": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-232": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-233": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-234": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-235": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-236": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-237": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-238": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-239": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-24": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-240": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-241": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-242": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-243": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-244": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-245": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-246": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-247": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-248": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-249": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-25": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-250": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-26": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-27": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-28": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-29": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-30": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-31": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-32": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-33": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-34": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-35": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-36": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-37": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-38": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-39": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-40": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-41": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-42": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-43": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-44": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-45": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-46": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-47": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-48": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-49": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-50": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-51": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-52": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-53": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-54": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-55": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-56": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-57": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-58": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-59": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-60": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-61": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-62": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-63": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-64": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-65": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-66": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-67": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-68": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-69": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-70": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-71": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-72": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-73": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-75": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-76": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-77": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-78": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-79": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-80": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-81": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-82": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-84": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-85": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-86": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-88": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-89": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-90": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-91": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-92": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-93": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-94": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-96": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-97": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-98": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/15.2.3.3-4-99": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptor/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptors/duplicate-keys": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptors/function-length": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptors/function-name": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptors/function-property-descriptor": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptors/inherited-properties-omitted": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptors/normal-object": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptors/observable-operations": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptors/primitive-booleans": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptors/primitive-numbers": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptors/primitive-strings": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptors/primitive-symbols": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptors/symbols-included": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptors/tamper-with-global-object": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyDescriptors/tamper-with-object-keys": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyNames/15.2.3.4-0-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyNames/15.2.3.4-0-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyNames/15.2.3.4-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyNames/15.2.3.4-1-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyNames/15.2.3.4-1-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyNames/15.2.3.4-2-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyNames/15.2.3.4-2-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyNames/15.2.3.4-2-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyNames/15.2.3.4-2-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyNames/15.2.3.4-3-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyNames/15.2.3.4-4-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyNames/15.2.3.4-4-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyNames/15.2.3.4-4-36": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyNames/15.2.3.4-4-37": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyNames/15.2.3.4-4-38": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyNames/15.2.3.4-4-39": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyNames/15.2.3.4-4-40": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyNames/15.2.3.4-4-41": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyNames/15.2.3.4-4-42": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyNames/15.2.3.4-4-43": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyNames/15.2.3.4-4-44": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyNames/15.2.3.4-4-45": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyNames/15.2.3.4-4-46": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyNames/15.2.3.4-4-47": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyNames/15.2.3.4-4-48": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyNames/15.2.3.4-4-49": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyNames/15.2.3.4-4-50": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyNames/15.2.3.4-4-b-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyNames/15.2.3.4-4-b-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyNames/15.2.3.4-4-b-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyNames/15.2.3.4-4-b-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyNames/15.2.3.4-4-b-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyNames/15.2.3.4-4-b-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyNames/S15.2.3.4_A1_T1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertyNames/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertySymbols/length": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertySymbols/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertySymbols/object-contains-symbol-property-with-description": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/getOwnPropertySymbols/object-contains-symbol-property-without-description": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/is/length": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/is/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/is/not-same-value-x-y-boolean": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/is/not-same-value-x-y-null": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/is/not-same-value-x-y-number": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/is/not-same-value-x-y-object": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/is/not-same-value-x-y-string": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/is/not-same-value-x-y-symbol": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/is/not-same-value-x-y-type": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/is/not-same-value-x-y-undefined": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/is/object-is": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/is/same-value-x-y-boolean": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/is/same-value-x-y-empty": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/is/same-value-x-y-null": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/is/same-value-x-y-number": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/is/same-value-x-y-object": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/is/same-value-x-y-string": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/is/same-value-x-y-symbol": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/is/same-value-x-y-undefined": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/is/symbol-object-is-same-value": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isExtensible/15.2.3.13-0-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isExtensible/15.2.3.13-0-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isExtensible/15.2.3.13-0-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isExtensible/15.2.3.13-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isExtensible/15.2.3.13-1-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isExtensible/15.2.3.13-1-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isExtensible/15.2.3.13-1-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isExtensible/15.2.3.13-1-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isExtensible/15.2.3.13-2-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isExtensible/15.2.3.13-2-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isExtensible/15.2.3.13-2-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isExtensible/15.2.3.13-2-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isExtensible/15.2.3.13-2-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isExtensible/15.2.3.13-2-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isExtensible/15.2.3.13-2-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isExtensible/15.2.3.13-2-16": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isExtensible/15.2.3.13-2-17": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isExtensible/15.2.3.13-2-18": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isExtensible/15.2.3.13-2-19": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isExtensible/15.2.3.13-2-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isExtensible/15.2.3.13-2-20": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isExtensible/15.2.3.13-2-21": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isExtensible/15.2.3.13-2-22": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isExtensible/15.2.3.13-2-23": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isExtensible/15.2.3.13-2-24": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isExtensible/15.2.3.13-2-25": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isExtensible/15.2.3.13-2-26": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isExtensible/15.2.3.13-2-27": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isExtensible/15.2.3.13-2-29": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isExtensible/15.2.3.13-2-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isExtensible/15.2.3.13-2-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isExtensible/15.2.3.13-2-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isExtensible/15.2.3.13-2-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isExtensible/15.2.3.13-2-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isExtensible/15.2.3.13-2-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isExtensible/15.2.3.13-2-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isExtensible/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isFrozen/15.2.3.12-0-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isFrozen/15.2.3.12-0-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isFrozen/15.2.3.12-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isFrozen/15.2.3.12-1-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isFrozen/15.2.3.12-1-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isFrozen/15.2.3.12-1-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isFrozen/15.2.3.12-1-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isFrozen/15.2.3.12-1-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isFrozen/15.2.3.12-1-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isFrozen/15.2.3.12-1-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isFrozen/15.2.3.12-2-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isFrozen/15.2.3.12-2-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isFrozen/15.2.3.12-2-a-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isFrozen/15.2.3.12-2-a-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isFrozen/15.2.3.12-2-a-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isFrozen/15.2.3.12-2-a-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isFrozen/15.2.3.12-2-a-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isFrozen/15.2.3.12-2-a-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isFrozen/15.2.3.12-2-a-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isFrozen/15.2.3.12-2-a-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isFrozen/15.2.3.12-2-a-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isFrozen/15.2.3.12-2-a-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isFrozen/15.2.3.12-2-a-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isFrozen/15.2.3.12-2-a-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isFrozen/15.2.3.12-2-b-i-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isFrozen/15.2.3.12-2-c-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isFrozen/15.2.3.12-2-c-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isFrozen/15.2.3.12-3-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isFrozen/15.2.3.12-3-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isFrozen/15.2.3.12-3-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isFrozen/15.2.3.12-3-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isFrozen/15.2.3.12-3-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isFrozen/15.2.3.12-3-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isFrozen/15.2.3.12-3-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isFrozen/15.2.3.12-3-16": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isFrozen/15.2.3.12-3-17": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isFrozen/15.2.3.12-3-18": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isFrozen/15.2.3.12-3-19": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isFrozen/15.2.3.12-3-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isFrozen/15.2.3.12-3-20": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isFrozen/15.2.3.12-3-21": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isFrozen/15.2.3.12-3-22": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isFrozen/15.2.3.12-3-23": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isFrozen/15.2.3.12-3-24": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isFrozen/15.2.3.12-3-25": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isFrozen/15.2.3.12-3-26": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isFrozen/15.2.3.12-3-27": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isFrozen/15.2.3.12-3-28": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isFrozen/15.2.3.12-3-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isFrozen/15.2.3.12-3-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isFrozen/15.2.3.12-3-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isFrozen/15.2.3.12-3-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isFrozen/15.2.3.12-3-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isFrozen/15.2.3.12-3-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isFrozen/15.2.3.12-3-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isFrozen/15.2.3.12-4-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isFrozen/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isSealed/15.2.3.11-0-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isSealed/15.2.3.11-0-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isSealed/15.2.3.11-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isSealed/15.2.3.11-4-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isSealed/15.2.3.11-4-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isSealed/15.2.3.11-4-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isSealed/15.2.3.11-4-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isSealed/15.2.3.11-4-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isSealed/15.2.3.11-4-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isSealed/15.2.3.11-4-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isSealed/15.2.3.11-4-16": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isSealed/15.2.3.11-4-17": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isSealed/15.2.3.11-4-18": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isSealed/15.2.3.11-4-19": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isSealed/15.2.3.11-4-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isSealed/15.2.3.11-4-20": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isSealed/15.2.3.11-4-21": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isSealed/15.2.3.11-4-22": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isSealed/15.2.3.11-4-23": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isSealed/15.2.3.11-4-24": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isSealed/15.2.3.11-4-25": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isSealed/15.2.3.11-4-26": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isSealed/15.2.3.11-4-27": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isSealed/15.2.3.11-4-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isSealed/15.2.3.11-4-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isSealed/15.2.3.11-4-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isSealed/15.2.3.11-4-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isSealed/15.2.3.11-4-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isSealed/15.2.3.11-4-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isSealed/15.2.3.11-4-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/isSealed/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/preventExtensions/15.2.3.10-0-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/preventExtensions/15.2.3.10-0-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/preventExtensions/15.2.3.10-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/preventExtensions/15.2.3.10-1-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/preventExtensions/15.2.3.10-1-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/preventExtensions/15.2.3.10-1-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/preventExtensions/15.2.3.10-1-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/preventExtensions/15.2.3.10-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/preventExtensions/15.2.3.10-2-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/preventExtensions/15.2.3.10-3-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/preventExtensions/15.2.3.10-3-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/preventExtensions/15.2.3.10-3-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/preventExtensions/15.2.3.10-3-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/preventExtensions/15.2.3.10-3-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/preventExtensions/15.2.3.10-3-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/preventExtensions/15.2.3.10-3-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/preventExtensions/15.2.3.10-3-16": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/preventExtensions/15.2.3.10-3-17": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/preventExtensions/15.2.3.10-3-18": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/preventExtensions/15.2.3.10-3-19": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/preventExtensions/15.2.3.10-3-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/preventExtensions/15.2.3.10-3-20": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/preventExtensions/15.2.3.10-3-21": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/preventExtensions/15.2.3.10-3-22": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/preventExtensions/15.2.3.10-3-23": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/preventExtensions/15.2.3.10-3-24": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/preventExtensions/15.2.3.10-3-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/preventExtensions/15.2.3.10-3-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/preventExtensions/15.2.3.10-3-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/preventExtensions/15.2.3.10-3-5-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/preventExtensions/15.2.3.10-3-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/preventExtensions/15.2.3.10-3-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/preventExtensions/15.2.3.10-3-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/preventExtensions/15.2.3.10-3-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/preventExtensions/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/preventExtensions/symbol-object-contains-symbol-properties-non-strict": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/seal/15.2.3.8-0-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/seal/15.2.3.8-0-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/seal/15.2.3.8-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/seal/15.2.3.8-1-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/seal/15.2.3.8-1-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/seal/15.2.3.8-1-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/seal/15.2.3.8-1-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/seal/15.2.3.8-2-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/seal/15.2.3.8-2-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/seal/15.2.3.8-2-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/seal/15.2.3.8-2-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/seal/15.2.3.8-2-a-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/seal/15.2.3.8-2-a-10": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/seal/15.2.3.8-2-a-11": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/seal/15.2.3.8-2-a-12": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/seal/15.2.3.8-2-a-13": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/seal/15.2.3.8-2-a-14": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/seal/15.2.3.8-2-a-15": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/seal/15.2.3.8-2-a-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/seal/15.2.3.8-2-a-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/seal/15.2.3.8-2-a-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/seal/15.2.3.8-2-a-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/seal/15.2.3.8-2-a-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/seal/15.2.3.8-2-a-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/seal/15.2.3.8-2-a-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/seal/15.2.3.8-2-a-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/seal/15.2.3.8-2-b-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/seal/15.2.3.8-2-b-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/seal/15.2.3.8-2-b-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/seal/15.2.3.8-2-b-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/seal/15.2.3.8-2-c-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/seal/15.2.3.8-2-c-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/seal/15.2.3.8-2-c-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/seal/15.2.3.8-2-c-4": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/seal/15.2.3.8-2-c-5": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/seal/15.2.3.8-2-c-6": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/seal/15.2.3.8-2-c-7": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/seal/15.2.3.8-2-c-8": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/seal/15.2.3.8-2-c-9": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/seal/15.2.3.8-3-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/seal/15.2.3.8-4-1": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/seal/15.2.3.8-4-2": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/seal/15.2.3.8-4-3": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/seal/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/seal/symbol-object-contains-symbol-properties-non-strict": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/values/exception-during-enumeration": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/values/function-length": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/values/function-name": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/values/function-property-descriptor": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/values/getter-adding-key": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/values/getter-making-future-key-nonenumerable": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/values/getter-removing-future-key": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/values/inherited-properties-omitted": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/values/observable-operations": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/values/primitive-booleans": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/values/primitive-numbers": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/values/primitive-strings": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/values/primitive-symbols": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/values/symbols-omitted": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/values/tamper-with-global-object": {
+		"category": "not_es3"
+	},
+	"built-ins/Object/values/tamper-with-object-keys": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/S25.4.3.1_A1.1_T1": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/S25.4.3.1_A2.1_T1": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/S25.4.3.1_A2.2_T1": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/S25.4.3.1_A2.3_T1": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/S25.4.3.1_A2.4_T1": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/S25.4.3.1_A3.1_T1": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/S25.4.3.1_A4.1_T1": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/S25.4.3.1_A5.1_T1": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/Symbol.species/length": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/Symbol.species/prop-desc": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/Symbol.species/return-value": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/Symbol.species/symbol-species": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/Symbol.species/symbol-species-name": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/all/S25.4.4.1_A1.1_T1": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/all/S25.4.4.1_A2.1_T1": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/all/S25.4.4.1_A2.2_T1": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/all/S25.4.4.1_A2.3_T1": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/all/S25.4.4.1_A2.3_T2": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/all/S25.4.4.1_A2.3_T3": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/all/S25.4.4.1_A3.1_T1": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/all/S25.4.4.1_A3.1_T2": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/all/S25.4.4.1_A3.1_T3": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/all/S25.4.4.1_A4.1_T1": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/all/S25.4.4.1_A5.1_T1": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/all/S25.4.4.1_A6.1_T1": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/all/S25.4.4.1_A6.1_T2": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/all/S25.4.4.1_A7.1_T1": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/all/S25.4.4.1_A7.2_T1": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/all/S25.4.4.1_A8.1_T1": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/all/S25.4.4.1_A8.2_T1": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/all/S25.4.4.1_A8.2_T2": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/all/call-resolve-element": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/all/call-resolve-element-after-return": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/all/call-resolve-element-items": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/all/capability-executor-called-twice": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/all/capability-executor-not-callable": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/all/ctx-ctor": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/all/ctx-ctor-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/all/ctx-non-ctor": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/all/ctx-non-object": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/all/does-not-invoke-array-setters": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/all/invoke-resolve": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/all/invoke-resolve-get-error": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/all/invoke-resolve-return": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/all/invoke-then": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/all/invoke-then-error": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/all/iter-close": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/all/iter-next-val-err": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/all/iter-step-err": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/all/length": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/all/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/all/new-resolve-function": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/all/prop-desc": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/all/reject-deferred": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/all/reject-ignored-deferred": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/all/reject-ignored-immed": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/all/reject-immed": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/all/resolve-before-loop-exit": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/all/resolve-before-loop-exit-from-same": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/all/resolve-element-function-extensible": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/all/resolve-element-function-length": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/all/resolve-element-function-name": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/all/resolve-element-function-nonconstructor": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/all/resolve-element-function-prototype": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/all/resolve-from-same-thenable": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/all/resolve-non-thenable": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/all/resolve-poisoned-then": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/all/resolve-thenable": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/all/same-reject-function": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/all/species-get-error": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/exception-after-resolve-in-executor": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/exception-after-resolve-in-thenable-job": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/exec-args": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/executor-function-extensible": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/executor-function-length": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/executor-function-name": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/executor-function-nonconstructor": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/executor-function-prototype": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/length": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/S25.4.4.2_A1.1_T1": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/S25.4.5_A1.1_T1": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/S25.4.5_A2.1_T1": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/S25.4.5_A3.1_T1": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/Symbol.toStringTag": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/catch/S25.4.5.1_A1.1_T1": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/catch/S25.4.5.1_A2.1_T1": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/catch/S25.4.5.1_A3.1_T1": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/catch/S25.4.5.1_A3.1_T2": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/catch/invokes-then": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/catch/length": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/catch/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/catch/prop-desc": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/S25.4.4_A1.1_T1": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/S25.4.4_A2.1_T1": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/S25.4.4_A2.1_T2": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/S25.4.4_A2.1_T3": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/S25.4.5.3_A1.1_T1": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/S25.4.5.3_A1.1_T2": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/S25.4.5.3_A2.1_T1": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/S25.4.5.3_A2.1_T2": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/S25.4.5.3_A4.1_T1": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/S25.4.5.3_A4.1_T2": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/S25.4.5.3_A4.2_T1": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/S25.4.5.3_A4.2_T2": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/S25.4.5.3_A5.1_T1": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/S25.4.5.3_A5.2_T1": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/S25.4.5.3_A5.3_T1": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/capability-executor-called-twice": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/capability-executor-not-callable": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/context-check-on-entry": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/ctor-access-count": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/ctor-custom": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/ctor-null": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/ctor-poisoned": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/ctor-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/ctor-undef": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/deferred-is-resolved-value": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/length": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/prfm-fulfilled": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/prfm-pending-fulfulled": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/prfm-pending-rejected": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/prfm-rejected": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/prop-desc": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/reject-pending-fulfilled": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/reject-pending-rejected": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/reject-settled-fulfilled": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/reject-settled-rejected": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/resolve-pending-fulfilled-non-obj": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/resolve-pending-fulfilled-non-thenable": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/resolve-pending-fulfilled-poisoned-then": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/resolve-pending-fulfilled-prms-cstm-then": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/resolve-pending-fulfilled-self": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/resolve-pending-fulfilled-thenable": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/resolve-pending-rejected-non-obj": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/resolve-pending-rejected-non-thenable": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/resolve-pending-rejected-poisoned-then": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/resolve-pending-rejected-prms-cstm-then": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/resolve-pending-rejected-self": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/resolve-pending-rejected-thenable": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/resolve-settled-fulfilled-non-obj": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/resolve-settled-fulfilled-non-thenable": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/resolve-settled-fulfilled-poisoned-then": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/resolve-settled-fulfilled-prms-cstm-then": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/resolve-settled-fulfilled-self": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/resolve-settled-fulfilled-thenable": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/resolve-settled-rejected-non-obj": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/resolve-settled-rejected-non-thenable": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/resolve-settled-rejected-poisoned-then": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/resolve-settled-rejected-prms-cstm-then": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/resolve-settled-rejected-self": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/resolve-settled-rejected-thenable": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/rxn-handler-fulfilled-invoke-nonstrict": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/rxn-handler-fulfilled-next": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/rxn-handler-fulfilled-next-abrupt": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/rxn-handler-fulfilled-return-abrupt": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/rxn-handler-fulfilled-return-normal": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/rxn-handler-identity": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/rxn-handler-rejected-invoke-nonstrict": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/rxn-handler-rejected-next": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/rxn-handler-rejected-next-abrupt": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/rxn-handler-rejected-return-abrupt": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/rxn-handler-rejected-return-normal": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/prototype/then/rxn-handler-thrower": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/race/S25.4.4.3_A1.1_T1": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/race/S25.4.4.3_A2.1_T1": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/race/S25.4.4.3_A2.2_T1": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/race/S25.4.4.3_A2.2_T2": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/race/S25.4.4.3_A2.2_T3": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/race/S25.4.4.3_A3.1_T1": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/race/S25.4.4.3_A3.1_T2": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/race/S25.4.4.3_A4.1_T1": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/race/S25.4.4.3_A4.1_T2": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/race/S25.4.4.3_A5.1_T1": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/race/S25.4.4.3_A6.1_T1": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/race/S25.4.4.3_A6.2_T1": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/race/S25.4.4.3_A7.1_T1": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/race/S25.4.4.3_A7.1_T2": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/race/S25.4.4.3_A7.1_T3": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/race/S25.4.4.3_A7.2_T1": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/race/S25.4.4.3_A7.3_T1": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/race/S25.4.4.3_A7.3_T2": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/race/capability-executor-called-twice": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/race/capability-executor-not-callable": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/race/ctx-ctor": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/race/ctx-ctor-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/race/ctx-non-ctor": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/race/ctx-non-object": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/race/invoke-resolve": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/race/invoke-resolve-get-error": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/race/invoke-resolve-return": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/race/invoke-then": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/race/invoke-then-error": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/race/iter-close": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/race/iter-next-val-err": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/race/iter-step-err": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/race/length": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/race/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/race/prop-desc": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/race/reject-deferred": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/race/reject-ignored-deferred": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/race/reject-ignored-immed": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/race/reject-immed": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/race/resolve-non-obj": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/race/resolve-non-thenable": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/race/resolve-poisoned-then": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/race/resolve-prms-cstm-then": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/race/resolve-self": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/race/resolve-thenable": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/race/same-reject-function": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/race/same-resolve-function": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/race/species-get-error": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/reject-function-extensible": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/reject-function-length": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/reject-function-name": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/reject-function-nonconstructor": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/reject-function-prototype": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/reject-ignored-via-abrupt": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/reject-ignored-via-fn-deferred": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/reject-ignored-via-fn-immed": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/reject-via-abrupt": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/reject-via-fn-deferred": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/reject-via-fn-immed": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/reject/S25.4.4.4_A1.1_T1": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/reject/S25.4.4.4_A2.1_T1": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/reject/S25.4.4.4_A3.1_T1": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/reject/capability-executor-called-twice": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/reject/capability-executor-not-callable": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/reject/ctx-ctor": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/reject/ctx-ctor-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/reject/ctx-non-ctor": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/reject/ctx-non-object": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/reject/length": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/reject/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/reject/prop-desc": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/resolve-function-extensible": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/resolve-function-length": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/resolve-function-name": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/resolve-function-nonconstructor": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/resolve-function-prototype": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/resolve-non-obj-deferred": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/resolve-non-obj-immed": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/resolve-non-thenable-deferred": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/resolve-non-thenable-immed": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/resolve-poisoned-then-deferred": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/resolve-poisoned-then-immed": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/resolve-prms-cstm-then-deferred": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/resolve-prms-cstm-then-immed": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/resolve-self": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/resolve-thenable-deferred": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/resolve-thenable-immed": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/resolve/S25.4.4.5_A1.1_T1": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/resolve/S25.4.4.5_A2.1_T1": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/resolve/S25.4.4.5_A2.2_T1": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/resolve/S25.4.4.5_A2.3_T1": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/resolve/S25.4.4.5_A3.1_T1": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/resolve/S25.4.4.5_A4.1_T1": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/resolve/S25.Promise_resolve_foreign_thenable_1": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/resolve/S25.Promise_resolve_foreign_thenable_2": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/resolve/arg-non-thenable": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/resolve/arg-poisoned-then": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/resolve/arg-uniq-ctor": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/resolve/capability-executor-called-twice": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/resolve/capability-executor-not-callable": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/resolve/context-non-object-with-promise": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/resolve/ctx-ctor": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/resolve/ctx-ctor-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/resolve/ctx-non-ctor": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/resolve/ctx-non-object": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/resolve/length": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/resolve/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/resolve/prop-desc": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/resolve/resolve-from-promise-capability": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/resolve/resolve-non-obj": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/resolve/resolve-non-thenable": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/resolve/resolve-poisoned-then": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/resolve/resolve-prms-cstm-then": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/resolve/resolve-self": {
+		"category": "not_es3"
+	},
+	"built-ins/Promise/resolve/resolve-thenable": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/apply/call-parameters": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/apply/call-result": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/apply/null-handler": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/apply/return-abrupt": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/apply/trap-is-not-callable": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/apply/trap-is-undefined": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/apply/trap-is-undefined-no-property": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/construct/call-parameters": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/construct/call-result": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/construct/null-handler": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/construct/return-is-abrupt": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/construct/return-not-object-throws-boolean": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/construct/return-not-object-throws-number": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/construct/return-not-object-throws-string": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/construct/return-not-object-throws-symbol": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/construct/return-not-object-throws-undefined": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/construct/trap-is-not-callable": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/construct/trap-is-undefined": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/construct/trap-is-undefined-no-property": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/constructor": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/create-handler-is-revoked-proxy": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/create-handler-not-object-throw-boolean": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/create-handler-not-object-throw-null": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/create-handler-not-object-throw-number": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/create-handler-not-object-throw-string": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/create-handler-not-object-throw-symbol": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/create-handler-not-object-throw-undefined": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/create-target-is-not-callable": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/create-target-is-not-constructor": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/create-target-is-revoked-proxy": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/create-target-not-object-throw-boolean": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/create-target-not-object-throw-null": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/create-target-not-object-throw-number": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/create-target-not-object-throw-string": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/create-target-not-object-throw-symbol": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/create-target-not-object-throw-undefined": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/defineProperty/call-parameters": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/defineProperty/null-handler": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/defineProperty/return-boolean-and-define-target": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/defineProperty/return-is-abrupt": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/defineProperty/targetdesc-configurable-desc-not-configurable": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/defineProperty/targetdesc-not-compatible-descriptor": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/defineProperty/targetdesc-not-compatible-descriptor-not-configurable-target": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/defineProperty/targetdesc-undefined-not-configurable-descriptor": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/defineProperty/targetdesc-undefined-target-is-not-extensible": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/defineProperty/trap-is-not-callable": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/defineProperty/trap-is-undefined": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/defineProperty/trap-return-is-false": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/deleteProperty/boolean-trap-result-boolean-false": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/deleteProperty/boolean-trap-result-boolean-true": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/deleteProperty/call-parameters": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/deleteProperty/null-handler": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/deleteProperty/return-false-not-strict": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/deleteProperty/return-is-abrupt": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/deleteProperty/targetdesc-is-not-configurable": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/deleteProperty/targetdesc-is-undefined-return-true": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/deleteProperty/trap-is-not-callable": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/deleteProperty/trap-is-undefined-not-strict": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/enumerate/removed-does-not-trigger": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/function-prototype": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/get/accessor-get-is-undefined-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/get/call-parameters": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/get/not-same-value-configurable-false-writable-false-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/get/null-handler": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/get/return-is-abrupt": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/get/return-trap-result": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/get/return-trap-result-accessor-property": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/get/return-trap-result-configurable-false-writable-true": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/get/return-trap-result-configurable-true-assessor-get-undefined": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/get/return-trap-result-configurable-true-writable-false": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/get/return-trap-result-same-value-configurable-false-writable-false": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/get/trap-is-not-callable": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/get/trap-is-undefined": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/get/trap-is-undefined-no-property": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/getOwnPropertyDescriptor/call-parameters": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/getOwnPropertyDescriptor/null-handler": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/getOwnPropertyDescriptor/result-is-undefined": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/getOwnPropertyDescriptor/result-is-undefined-target-is-not-extensible": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/getOwnPropertyDescriptor/result-is-undefined-targetdesc-is-not-configurable": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/getOwnPropertyDescriptor/result-is-undefined-targetdesc-is-undefined": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/getOwnPropertyDescriptor/result-type-is-not-object-nor-undefined": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/getOwnPropertyDescriptor/resultdesc-is-invalid-descriptor": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/getOwnPropertyDescriptor/resultdesc-is-not-configurable-targetdesc-is-configurable": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/getOwnPropertyDescriptor/resultdesc-is-not-configurable-targetdesc-is-undefined": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/getOwnPropertyDescriptor/resultdesc-return-configurable": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/getOwnPropertyDescriptor/resultdesc-return-not-configurable": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/getOwnPropertyDescriptor/return-is-abrupt": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/getOwnPropertyDescriptor/trap-is-not-callable": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/getOwnPropertyDescriptor/trap-is-undefined": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/getPrototypeOf/call-parameters": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/getPrototypeOf/extensible-target-return-handlerproto": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/getPrototypeOf/not-extensible-not-same-proto-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/getPrototypeOf/not-extensible-same-proto": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/getPrototypeOf/null-handler": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/getPrototypeOf/return-is-abrupt": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/getPrototypeOf/trap-is-not-callable": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/getPrototypeOf/trap-is-undefined": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/getPrototypeOf/trap-result-neither-object-nor-null-throws-boolean": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/getPrototypeOf/trap-result-neither-object-nor-null-throws-number": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/getPrototypeOf/trap-result-neither-object-nor-null-throws-string": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/getPrototypeOf/trap-result-neither-object-nor-null-throws-symbol": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/getPrototypeOf/trap-result-neither-object-nor-null-throws-undefined": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/has/call-in": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/has/call-object-create": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/has/call-with": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/has/null-handler": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/has/null-handler-using-with": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/has/return-false-target-not-extensible": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/has/return-false-target-not-extensible-using-with": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/has/return-false-target-prop-exists": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/has/return-false-target-prop-exists-using-with": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/has/return-false-targetdesc-not-configurable": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/has/return-false-targetdesc-not-configurable-using-with": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/has/return-is-abrupt-in": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/has/return-is-abrupt-with": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/has/return-true-target-prop-exists": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/has/return-true-target-prop-exists-using-with": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/has/return-true-without-same-target-prop": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/has/trap-is-not-callable": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/has/trap-is-not-callable-using-with": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/has/trap-is-undefined": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/has/trap-is-undefined-using-with": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/isExtensible/call-parameters": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/isExtensible/null-handler": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/isExtensible/return-is-abrupt": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/isExtensible/return-is-boolean": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/isExtensible/return-is-different-from-target": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/isExtensible/return-same-result-from-target": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/isExtensible/trap-is-not-callable": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/isExtensible/trap-is-undefined": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/length": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/ownKeys/call-parameters-object-getownpropertynames": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/ownKeys/call-parameters-object-getownpropertysymbols": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/ownKeys/call-parameters-object-keys": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/ownKeys/extensible-return-trap-result": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/ownKeys/extensible-return-trap-result-absent-not-configurable-keys": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/ownKeys/not-extensible-missing-keys-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/ownKeys/not-extensible-new-keys-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/ownKeys/not-extensible-return-keys": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/ownKeys/null-handler": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/ownKeys/return-all-non-configurable-keys": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/ownKeys/return-is-abrupt": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/ownKeys/return-not-list-object-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/ownKeys/trap-is-not-callable": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/ownKeys/trap-is-undefined": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/preventExtensions/call-parameters": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/preventExtensions/null-handler": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/preventExtensions/return-false": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/preventExtensions/return-is-abrupt": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/preventExtensions/return-true-target-is-extensible": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/preventExtensions/return-true-target-is-not-extensible": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/preventExtensions/trap-is-not-callable": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/preventExtensions/trap-is-undefined": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/proxy": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/proxy-newtarget": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/proxy-no-prototype": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/proxy-undefined-newtarget": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/revocable/length": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/revocable/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/revocable/proxy": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/revocable/revocation-function-extensible": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/revocable/revocation-function-length": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/revocable/revocation-function-name": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/revocable/revocation-function-nonconstructor": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/revocable/revocation-function-prototype": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/revocable/revoke": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/revocable/revoke-consecutive-call-returns-undefined": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/revocable/revoke-returns-undefined": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/set/boolean-trap-result-is-false-boolean-return-false": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/set/boolean-trap-result-is-false-null-return-false": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/set/boolean-trap-result-is-false-number-return-false": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/set/boolean-trap-result-is-false-string-return-false": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/set/boolean-trap-result-is-false-undefined-return-false": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/set/call-parameters": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/set/null-handler": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/set/return-is-abrupt": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/set/return-true-target-property-accessor-is-configurable-set-is-undefined": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/set/return-true-target-property-accessor-is-not-configurable": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/set/return-true-target-property-is-not-configurable": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/set/return-true-target-property-is-not-writable": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/set/target-property-is-accessor-not-configurable-set-is-undefined": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/set/target-property-is-not-configurable-not-writable-not-equal-to-v": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/set/trap-is-not-callable": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/set/trap-is-undefined": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/set/trap-is-undefined-no-property": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/setPrototypeOf/call-parameters": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/setPrototypeOf/not-extensible-target-not-same-target-prototype": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/setPrototypeOf/not-extensible-target-same-target-prototype": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/setPrototypeOf/not-extensible-trap-is-false-return-false": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/setPrototypeOf/null-handler": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/setPrototypeOf/return-is-abrupt": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/setPrototypeOf/trap-is-not-callable": {
+		"category": "not_es3"
+	},
+	"built-ins/Proxy/setPrototypeOf/trap-is-undefined": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/Reflect": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/apply/apply": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/apply/arguments-list-is-not-array-like": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/apply/call-target": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/apply/length": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/apply/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/apply/return-target-call-result": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/apply/target-is-not-callable-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/construct/arguments-list-is-not-array-like": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/construct/construct": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/construct/length": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/construct/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/construct/newtarget-is-not-constructor-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/construct/return-with-newtarget-argument": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/construct/return-without-newtarget-argument": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/construct/target-is-not-constructor-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/construct/use-arguments-list": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/defineProperty/define-properties": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/defineProperty/define-symbol-properties": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/defineProperty/defineProperty": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/defineProperty/length": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/defineProperty/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/defineProperty/return-abrupt-from-attributes": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/defineProperty/return-abrupt-from-property-key": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/defineProperty/return-abrupt-from-result": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/defineProperty/return-boolean": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/defineProperty/target-is-not-object-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/defineProperty/target-is-symbol-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/deleteProperty/delete-properties": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/deleteProperty/delete-symbol-properties": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/deleteProperty/deleteProperty": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/deleteProperty/length": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/deleteProperty/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/deleteProperty/return-abrupt-from-property-key": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/deleteProperty/return-abrupt-from-result": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/deleteProperty/return-boolean": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/deleteProperty/target-is-not-object-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/deleteProperty/target-is-symbol-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/enumerate/undefined": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/get/get": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/get/length": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/get/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/get/return-abrupt-from-property-key": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/get/return-abrupt-from-result": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/get/return-value": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/get/return-value-from-receiver": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/get/return-value-from-symbol-key": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/get/target-is-not-object-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/get/target-is-symbol-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/getOwnPropertyDescriptor/getOwnPropertyDescriptor": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/getOwnPropertyDescriptor/length": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/getOwnPropertyDescriptor/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/getOwnPropertyDescriptor/return-abrupt-from-property-key": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/getOwnPropertyDescriptor/return-abrupt-from-result": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/getOwnPropertyDescriptor/return-from-accessor-descriptor": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/getOwnPropertyDescriptor/return-from-data-descriptor": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/getOwnPropertyDescriptor/symbol-property": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/getOwnPropertyDescriptor/target-is-not-object-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/getOwnPropertyDescriptor/target-is-symbol-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/getOwnPropertyDescriptor/undefined-own-property": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/getOwnPropertyDescriptor/undefined-property": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/getPrototypeOf/getPrototypeOf": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/getPrototypeOf/length": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/getPrototypeOf/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/getPrototypeOf/null-prototype": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/getPrototypeOf/return-abrupt-from-result": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/getPrototypeOf/return-prototype": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/getPrototypeOf/skip-own-properties": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/getPrototypeOf/target-is-not-object-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/getPrototypeOf/target-is-symbol-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/has/has": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/has/length": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/has/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/has/return-abrupt-from-property-key": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/has/return-abrupt-from-result": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/has/return-boolean": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/has/symbol-property": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/has/target-is-not-object-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/has/target-is-symbol-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/isExtensible/isExtensible": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/isExtensible/length": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/isExtensible/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/isExtensible/return-abrupt-from-result": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/isExtensible/return-boolean": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/isExtensible/target-is-not-object-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/isExtensible/target-is-symbol-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/object-prototype": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/ownKeys/length": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/ownKeys/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/ownKeys/ownKeys": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/ownKeys/return-abrupt-from-result": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/ownKeys/return-array-with-own-keys-only": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/ownKeys/return-empty-array": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/ownKeys/return-non-enumerable-keys": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/ownKeys/return-on-corresponding-order": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/ownKeys/target-is-not-object-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/ownKeys/target-is-symbol-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/preventExtensions/always-return-true-from-ordinary-object": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/preventExtensions/length": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/preventExtensions/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/preventExtensions/prevent-extensions": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/preventExtensions/preventExtensions": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/preventExtensions/return-abrupt-from-result": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/preventExtensions/return-boolean-from-proxy-object": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/preventExtensions/target-is-not-object-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/preventExtensions/target-is-symbol-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/properties": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/set/call-prototype-property-set": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/set/creates-a-data-descriptor": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/set/different-property-descriptors": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/set/length": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/set/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/set/receiver-is-not-object": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/set/return-abrupt-from-property-key": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/set/return-abrupt-from-result": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/set/return-false-if-receiver-is-not-writable": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/set/return-false-if-target-is-not-writable": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/set/set": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/set/set-value-on-accessor-descriptor": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/set/set-value-on-accessor-descriptor-with-receiver": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/set/set-value-on-data-descriptor": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/set/symbol-property": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/set/target-is-not-object-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/set/target-is-symbol-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/setPrototypeOf/length": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/setPrototypeOf/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/setPrototypeOf/proto-is-not-object-and-not-null-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/setPrototypeOf/proto-is-symbol-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/setPrototypeOf/return-abrupt-from-result": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/setPrototypeOf/return-false-if-target-and-proto-are-the-same": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/setPrototypeOf/return-false-if-target-is-not-extensible": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/setPrototypeOf/return-false-if-target-is-prototype-of-proto": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/setPrototypeOf/return-true-if-new-prototype-is-set": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/setPrototypeOf/return-true-if-proto-is-current": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/setPrototypeOf/setPrototypeOf": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/setPrototypeOf/target-is-not-object-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/Reflect/setPrototypeOf/target-is-symbol-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/Symbol.species/length": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/Symbol.species/symbol-species": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/Symbol.species/symbol-species-name": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.match/builtin-coerce-global": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.match/builtin-coerce-lastindex": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.match/builtin-coerce-lastindex-err": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.match/builtin-coerce-sticky": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.match/builtin-failure-return-val": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.match/builtin-failure-set-lastindex": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.match/builtin-failure-set-lastindex-err": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.match/builtin-failure-y-return-val": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.match/builtin-failure-y-set-lastindex": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.match/builtin-failure-y-set-lastindex-err": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.match/builtin-get-global-err": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.match/builtin-get-sticky-err": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.match/builtin-infer-unicode": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.match/builtin-success-g-set-lastindex": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.match/builtin-success-g-set-lastindex-err": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.match/builtin-success-return-val": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.match/builtin-success-return-val-groups": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.match/builtin-success-u-return-val-groups": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.match/builtin-success-y-set-lastindex": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.match/builtin-success-y-set-lastindex-err": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.match/coerce-arg": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.match/coerce-arg-err": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.match/coerce-global": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.match/coerce-sticky": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.match/exec-err": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.match/exec-invocation": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.match/exec-return-type-invalid": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.match/exec-return-type-valid": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.match/g-coerce-result-err": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.match/g-get-exec-err": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.match/g-get-result-err": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.match/g-init-lastindex": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.match/g-init-lastindex-err": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.match/g-match-empty-advance-lastindex": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.match/g-match-empty-coerce-lastindex-err": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.match/g-match-empty-set-lastindex-err": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.match/g-match-no-coerce-lastindex": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.match/g-match-no-set-lastindex": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.match/g-success-return-val": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.match/g-zero-matches": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.match/get-exec-err": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.match/get-global-err": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.match/get-sticky-err": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.match/get-unicode-error": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.match/length": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.match/name": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.match/prop-desc": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.match/this-val-non-obj": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.match/this-val-non-regexp": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.match/u-advance-after-empty": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.match/y-fail-global-return": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.match/y-fail-lastindex": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.match/y-fail-lastindex-no-write": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.match/y-fail-return": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.match/y-init-lastindex": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.match/y-set-lastindex": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.replace/arg-1-coerce": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.replace/arg-1-coerce-err": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.replace/arg-2-coerce": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.replace/arg-2-coerce-err": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.replace/coerce-global": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.replace/coerce-unicode": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.replace/exec-err": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.replace/exec-invocation": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.replace/fn-coerce-replacement": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.replace/fn-coerce-replacement-err": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.replace/fn-err": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.replace/fn-invoke-args": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.replace/fn-invoke-this-no-strict": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.replace/g-init-lastindex": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.replace/g-init-lastindex-err": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.replace/g-pos-decrement": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.replace/g-pos-increment": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.replace/get-exec-err": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.replace/get-global-err": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.replace/get-sticky-coerce": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.replace/get-sticky-err": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.replace/get-unicode-error": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.replace/length": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.replace/match-failure": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.replace/name": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.replace/prop-desc": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.replace/replace-with-trailing": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.replace/replace-without-trailing": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.replace/result-coerce-capture": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.replace/result-coerce-capture-err": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.replace/result-coerce-index": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.replace/result-coerce-index-err": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.replace/result-coerce-length": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.replace/result-coerce-length-err": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.replace/result-coerce-matched": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.replace/result-coerce-matched-err": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.replace/result-get-capture-err": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.replace/result-get-index-err": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.replace/result-get-length-err": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.replace/result-get-matched-err": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.replace/subst-after": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.replace/subst-before": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.replace/subst-capture-idx-1": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.replace/subst-capture-idx-2": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.replace/subst-dollar": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.replace/subst-matched": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.replace/this-val-non-obj": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.replace/u-advance-after-empty": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.replace/y-fail-global-return": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.replace/y-fail-lastindex": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.replace/y-fail-lastindex-no-write": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.replace/y-fail-return": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.replace/y-init-lastindex": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.replace/y-set-lastindex": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.search/coerce-string": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.search/coerce-string-err": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.search/cstm-exec-return-index": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.search/cstm-exec-return-invalid": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.search/failure-return-val": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.search/get-lastindex-err": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.search/get-sticky-coerce": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.search/get-sticky-err": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.search/length": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.search/match-err": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.search/name": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.search/prop-desc": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.search/set-lastindex-init": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.search/set-lastindex-init-err": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.search/set-lastindex-restore": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.search/set-lastindex-restore-err": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.search/success-get-index-err": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.search/success-return-val": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.search/this-val-non-obj": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.search/u-lastindex-advance": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.search/y-fail-return": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.split/coerce-flags": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.split/coerce-flags-err": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.split/coerce-limit": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.split/coerce-limit-err": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.split/coerce-string": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.split/coerce-string-err": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.split/get-flags-err": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.split/last-index-exceeds-str-size": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.split/length": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.split/limit-0-bail": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.split/name": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.split/prop-desc": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.split/species-ctor": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.split/species-ctor-ctor-get-err": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.split/species-ctor-ctor-non-obj": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.split/species-ctor-ctor-undef": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.split/species-ctor-err": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.split/species-ctor-species-get-err": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.split/species-ctor-species-non-ctor": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.split/species-ctor-species-undef": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.split/species-ctor-y": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.split/str-adv-thru-empty-match": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.split/str-coerce-lastindex": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.split/str-coerce-lastindex-err": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.split/str-empty-match": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.split/str-empty-match-err": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.split/str-empty-no-match": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.split/str-get-lastindex-err": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.split/str-limit": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.split/str-limit-capturing": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.split/str-match-err": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.split/str-result-coerce-length": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.split/str-result-coerce-length-err": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.split/str-result-get-capture-err": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.split/str-result-get-length-err": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.split/str-set-lastindex-err": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.split/str-set-lastindex-match": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.split/str-set-lastindex-no-match": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.split/str-trailing-chars": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.split/this-val-non-obj": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.split/u-lastindex-adv-thru-failure": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/Symbol.split/u-lastindex-adv-thru-match": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/exec/get-sticky-coerce": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/exec/get-sticky-err": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/sticky/length": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/sticky/name": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/sticky/prop-desc": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/sticky/this-invalid-obj": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/sticky/this-non-obj": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/sticky/this-regexp": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/test/get-sticky-err": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/unicode/length": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/unicode/name": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/unicode/prop-desc": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/unicode/this-invald-obj": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/unicode/this-non-obj": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/prototype/unicode/this-regexp": {
+		"category": "not_es3"
+	},
+	"built-ins/RegExp/unicode_identity_escape": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/Symbol.species/length": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/Symbol.species/symbol-species": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/Symbol.species/symbol-species-name": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/constructor": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/length": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/properties-of-the-set-prototype-object": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype-of-set": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/Symbol.iterator": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/Symbol.toStringTag": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/Symbol.toStringTag/property-descriptor": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/add/add": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/add/does-not-have-setdata-internal-slot-array": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/add/does-not-have-setdata-internal-slot-map": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/add/does-not-have-setdata-internal-slot-object": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/add/does-not-have-setdata-internal-slot-set-prototype": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/add/does-not-have-setdata-internal-slot-weakset": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/add/length": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/add/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/add/preserves-insertion-order": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/add/returns-this": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/add/returns-this-when-ignoring-duplicate": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/add/this-not-object-throw-boolean": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/add/this-not-object-throw-null": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/add/this-not-object-throw-number": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/add/this-not-object-throw-string": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/add/this-not-object-throw-symbol": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/add/this-not-object-throw-undefined": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/add/will-not-add-duplicate-entry": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/add/will-not-add-duplicate-entry-initial-iterable": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/add/will-not-add-duplicate-entry-normalizes-zero": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/clear/clear": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/clear/clears-all-contents": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/clear/clears-all-contents-from-iterable": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/clear/clears-an-empty-set": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/clear/does-not-have-setdata-internal-slot-array": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/clear/does-not-have-setdata-internal-slot-map": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/clear/does-not-have-setdata-internal-slot-object": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/clear/does-not-have-setdata-internal-slot-set.prototype": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/clear/does-not-have-setdata-internal-slot-weakset": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/clear/length": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/clear/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/clear/returns-undefined": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/clear/this-not-object-throw-boolean": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/clear/this-not-object-throw-null": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/clear/this-not-object-throw-number": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/clear/this-not-object-throw-string": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/clear/this-not-object-throw-symbol": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/clear/this-not-object-throw-undefined": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/constructor/set-prototype-constructor": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/constructor/set-prototype-constructor-intrinsic": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/delete/delete": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/delete/delete-entry": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/delete/delete-entry-initial-iterable": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/delete/delete-entry-normalizes-zero": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/delete/does-not-have-setdata-internal-slot-array": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/delete/does-not-have-setdata-internal-slot-map": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/delete/does-not-have-setdata-internal-slot-object": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/delete/does-not-have-setdata-internal-slot-set-prototype": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/delete/does-not-have-setdata-internal-slot-weakset": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/delete/length": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/delete/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/delete/returns-false-when-delete-is-noop": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/delete/returns-true-when-delete-operation-occurs": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/delete/this-not-object-throw-boolean": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/delete/this-not-object-throw-null": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/delete/this-not-object-throw-number": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/delete/this-not-object-throw-string": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/delete/this-not-object-throw-symbol": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/delete/this-not-object-throw-undefined": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/entries/does-not-have-setdata-internal-slot-array": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/entries/does-not-have-setdata-internal-slot-map": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/entries/does-not-have-setdata-internal-slot-object": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/entries/does-not-have-setdata-internal-slot-set-prototype": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/entries/does-not-have-setdata-internal-slot-weakset": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/entries/entries": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/entries/length": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/entries/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/entries/returns-iterator": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/entries/returns-iterator-empty": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/entries/this-not-object-throw-boolean": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/entries/this-not-object-throw-null": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/entries/this-not-object-throw-number": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/entries/this-not-object-throw-string": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/entries/this-not-object-throw-symbol": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/entries/this-not-object-throw-undefined": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/forEach/callback-not-callable-boolean": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/forEach/callback-not-callable-null": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/forEach/callback-not-callable-number": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/forEach/callback-not-callable-string": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/forEach/callback-not-callable-symbol": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/forEach/callback-not-callable-undefined": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/forEach/does-not-have-setdata-internal-slot-array": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/forEach/does-not-have-setdata-internal-slot-map": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/forEach/does-not-have-setdata-internal-slot-object": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/forEach/does-not-have-setdata-internal-slot-set-prototype": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/forEach/does-not-have-setdata-internal-slot-weakset": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/forEach/forEach": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/forEach/iterates-in-insertion-order": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/forEach/iterates-in-iterable-entry-order": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/forEach/iterates-values-added-after-foreach-begins": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/forEach/iterates-values-deleted-then-readded": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/forEach/iterates-values-not-deleted": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/forEach/iterates-values-revisits-after-delete-re-add": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/forEach/length": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/forEach/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/forEach/returns-undefined": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/forEach/this-arg-explicit": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/forEach/this-arg-explicit-cannot-override-lexical-this-arrow": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/forEach/this-non-strict": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/forEach/this-not-object-throw-boolean": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/forEach/this-not-object-throw-null": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/forEach/this-not-object-throw-number": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/forEach/this-not-object-throw-string": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/forEach/this-not-object-throw-symbol": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/forEach/this-not-object-throw-undefined": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/forEach/throws-when-callback-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/has/does-not-have-setdata-internal-slot-array": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/has/does-not-have-setdata-internal-slot-map": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/has/does-not-have-setdata-internal-slot-object": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/has/does-not-have-setdata-internal-slot-set-prototype": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/has/does-not-have-setdata-internal-slot-weakset": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/has/has": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/has/length": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/has/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/has/returns-false-when-undefined-added-deleted-not-present-undefined": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/has/returns-false-when-value-not-present-boolean": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/has/returns-false-when-value-not-present-nan": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/has/returns-false-when-value-not-present-null": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/has/returns-false-when-value-not-present-number": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/has/returns-false-when-value-not-present-string": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/has/returns-false-when-value-not-present-symbol": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/has/returns-false-when-value-not-present-undefined": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/has/returns-true-when-value-present-boolean": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/has/returns-true-when-value-present-nan": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/has/returns-true-when-value-present-null": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/has/returns-true-when-value-present-number": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/has/returns-true-when-value-present-string": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/has/returns-true-when-value-present-symbol": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/has/returns-true-when-value-present-undefined": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/has/this-not-object-throw-boolean": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/has/this-not-object-throw-null": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/has/this-not-object-throw-number": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/has/this-not-object-throw-string": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/has/this-not-object-throw-symbol": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/has/this-not-object-throw-undefined": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/keys/keys": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/set-prototype": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/size/length": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/size/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/size/returns-count-of-present-values-before-after-add-delete": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/size/returns-count-of-present-values-by-insertion": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/size/returns-count-of-present-values-by-iterable": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/size/size": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/values/does-not-have-setdata-internal-slot-array": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/values/does-not-have-setdata-internal-slot-map": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/values/does-not-have-setdata-internal-slot-object": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/values/does-not-have-setdata-internal-slot-set-prototype": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/values/does-not-have-setdata-internal-slot-weakset": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/values/length": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/values/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/values/returns-iterator": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/values/returns-iterator-empty": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/values/this-not-object-throw-boolean": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/values/this-not-object-throw-null": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/values/this-not-object-throw-number": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/values/this-not-object-throw-string": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/values/this-not-object-throw-symbol": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/values/this-not-object-throw-undefined": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/values/values": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/prototype/values/values-iteration-mutable": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/set": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/set-does-not-throw-when-add-is-not-callable": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/set-get-add-method-failure": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/set-iterable": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/set-iterable-calls-add": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/set-iterable-empty-does-not-call-add": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/set-iterable-throws-when-add-is-not-callable": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/set-iterator-close-after-add-failure": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/set-iterator-next-failure": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/set-iterator-value-failure": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/set-newtarget": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/set-no-iterable": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/set-undefined-newtarget": {
+		"category": "not_es3"
+	},
+	"built-ins/Set/symbol-as-entry": {
+		"category": "not_es3"
+	},
+	"built-ins/SetIteratorPrototype/Symbol.toStringTag": {
+		"category": "not_es3"
+	},
+	"built-ins/String/fromCodePoint/argument-is-Symbol": {
+		"category": "not_es3"
+	},
+	"built-ins/String/fromCodePoint/argument-is-not-integer": {
+		"category": "not_es3"
+	},
+	"built-ins/String/fromCodePoint/argument-not-coercible": {
+		"category": "not_es3"
+	},
+	"built-ins/String/fromCodePoint/arguments-is-empty": {
+		"category": "not_es3"
+	},
+	"built-ins/String/fromCodePoint/fromCodePoint": {
+		"category": "not_es3"
+	},
+	"built-ins/String/fromCodePoint/length": {
+		"category": "not_es3"
+	},
+	"built-ins/String/fromCodePoint/name": {
+		"category": "not_es3"
+	},
+	"built-ins/String/fromCodePoint/number-is-out-of-range": {
+		"category": "not_es3"
+	},
+	"built-ins/String/fromCodePoint/return-string-value": {
+		"category": "not_es3"
+	},
+	"built-ins/String/fromCodePoint/to-number-conversions": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/Symbol.iterator/length": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/Symbol.iterator/name": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/Symbol.iterator/prop-desc": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/Symbol.iterator/this-val-non-obj-coercible": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/Symbol.iterator/this-val-to-str-err": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/codePointAt/codePointAt": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/codePointAt/length": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/codePointAt/name": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/codePointAt/return-abrupt-from-object-pos-to-integer": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/codePointAt/return-abrupt-from-symbol-pos-to-integer": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/codePointAt/return-abrupt-from-this": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/codePointAt/return-abrupt-from-this-as-symbol": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/codePointAt/return-code-unit-coerced-position": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/codePointAt/return-first-code-unit": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/codePointAt/return-single-code-unit": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/codePointAt/return-utf16-decode": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/codePointAt/returns-undefined-on-position-equal-or-more-than-size": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/codePointAt/returns-undefined-on-position-less-than-zero": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/endsWith/String.prototype.endsWith_Fail": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/endsWith/String.prototype.endsWith_Fail_2": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/endsWith/String.prototype.endsWith_Success": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/endsWith/String.prototype.endsWith_Success_2": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/endsWith/String.prototype.endsWith_Success_3": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/endsWith/String.prototype.endsWith_Success_4": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/endsWith/coerced-values-of-position": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/endsWith/endsWith": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/endsWith/length": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/endsWith/name": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/endsWith/return-abrupt-from-position": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/endsWith/return-abrupt-from-position-as-symbol": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/endsWith/return-abrupt-from-searchstring": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/endsWith/return-abrupt-from-searchstring-as-symbol": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/endsWith/return-abrupt-from-searchstring-regexp-test": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/endsWith/return-abrupt-from-this": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/endsWith/return-abrupt-from-this-as-symbol": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/endsWith/return-false-if-search-start-is-less-than-zero": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/endsWith/return-true-if-searchstring-is-empty": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/endsWith/searchstring-found-with-position": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/endsWith/searchstring-found-without-position": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/endsWith/searchstring-not-found-with-position": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/endsWith/searchstring-not-found-without-position": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/includes/String.prototype.includes_FailBadLocation": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/includes/String.prototype.includes_FailLocation": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/includes/String.prototype.includes_FailMissingLetter": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/includes/String.prototype.includes_Success": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/includes/String.prototype.includes_SuccessNoLocation": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/includes/String.prototype.includes_lengthProp": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/includes/coerced-values-of-position": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/includes/includes": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/includes/length": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/includes/name": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/includes/return-abrupt-from-position": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/includes/return-abrupt-from-position-as-symbol": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/includes/return-abrupt-from-searchstring": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/includes/return-abrupt-from-searchstring-as-symbol": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/includes/return-abrupt-from-searchstring-regexp-test": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/includes/return-abrupt-from-this": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/includes/return-abrupt-from-this-as-symbol": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/includes/return-false-with-out-of-bounds-position": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/includes/return-true-if-searchstring-is-empty": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/includes/searchstring-found-with-position": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/includes/searchstring-found-without-position": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/includes/searchstring-not-found-with-position": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/includes/searchstring-not-found-without-position": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/indexOf/S15.5.4.7_A1_T12": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/lastIndexOf/S15.5.4.8_A1_T12": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/match/cstm-matcher-get-err": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/match/cstm-matcher-invocation": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/match/invoke-builtin-match": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/normalize/form-is-not-valid-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/normalize/length": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/normalize/name": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/normalize/normalize": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/normalize/return-abrupt-from-form": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/normalize/return-abrupt-from-form-as-symbol": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/normalize/return-abrupt-from-this": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/normalize/return-abrupt-from-this-as-symbol": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/normalize/return-normalized-string": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/normalize/return-normalized-string-from-coerced-form": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/normalize/return-normalized-string-using-default-parameter": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/repeat/count-coerced-to-zero-returns-empty-string": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/repeat/count-is-infinity-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/repeat/count-is-zero-returns-empty-string": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/repeat/count-less-than-zero-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/repeat/empty-string-returns-empty": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/repeat/length": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/repeat/name": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/repeat/repeat": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/repeat/repeat-string-n-times": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/repeat/return-abrupt-from-count": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/repeat/return-abrupt-from-count-as-symbol": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/repeat/return-abrupt-from-this": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/repeat/return-abrupt-from-this-as-symbol": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/replace/cstm-replace-get-err": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/replace/cstm-replace-invocation": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/search/cstm-search-get-err": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/search/cstm-search-invocation": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/search/invoke-builtin-search": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/search/invoke-builtin-search-searcher-undef": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/split/cstm-split-get-err": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/split/cstm-split-invocation": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/startsWith/coerced-values-of-position": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/startsWith/length": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/startsWith/name": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/startsWith/out-of-bounds-position": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/startsWith/return-abrupt-from-position": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/startsWith/return-abrupt-from-position-as-symbol": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/startsWith/return-abrupt-from-searchstring": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/startsWith/return-abrupt-from-searchstring-as-symbol": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/startsWith/return-abrupt-from-searchstring-regexp-test": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/startsWith/return-abrupt-from-this": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/startsWith/return-abrupt-from-this-as-symbol": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/startsWith/return-true-if-searchstring-is-empty": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/startsWith/searchstring-found-with-position": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/startsWith/searchstring-found-without-position": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/startsWith/searchstring-not-found-with-position": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/startsWith/searchstring-not-found-without-position": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/startsWith/startsWith": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-0-1": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-0-2": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-1-3": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-1-4": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-1-5": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-1-6": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-1-7": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-1-8": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-1-9": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-2-1": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-2-10": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-2-11": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-2-12": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-2-13": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-2-14": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-2-15": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-2-16": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-2-17": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-2-18": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-2-19": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-2-2": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-2-20": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-2-21": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-2-22": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-2-23": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-2-24": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-2-25": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-2-26": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-2-27": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-2-28": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-2-29": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-2-3": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-2-30": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-2-31": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-2-32": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-2-33": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-2-34": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-2-35": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-2-36": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-2-37": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-2-38": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-2-39": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-2-4": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-2-40": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-2-41": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-2-42": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-2-43": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-2-44": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-2-45": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-2-46": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-2-47": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-2-49": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-2-5": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-2-50": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-2-51": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-2-6": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-2-7": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-2-8": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-2-9": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-3-1": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-3-10": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-3-11": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-3-12": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-3-13": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-3-14": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-3-2": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-3-3": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-3-4": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-3-5": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-3-6": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-3-7": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-3-8": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-3-9": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-4-1": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-4-10": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-4-11": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-4-12": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-4-13": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-4-14": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-4-16": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-4-18": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-4-19": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-4-2": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-4-20": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-4-21": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-4-22": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-4-24": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-4-27": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-4-28": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-4-29": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-4-3": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-4-30": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-4-32": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-4-34": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-4-35": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-4-36": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-4-37": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-4-38": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-4-39": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-4-4": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-4-40": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-4-41": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-4-42": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-4-43": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-4-44": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-4-45": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-4-46": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-4-47": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-4-48": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-4-49": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-4-5": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-4-50": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-4-51": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-4-52": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-4-53": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-4-54": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-4-55": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-4-56": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-4-57": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-4-58": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-4-59": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-4-6": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-4-60": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/15.5.4.20-4-8": {
+		"category": "not_es3"
+	},
+	"built-ins/String/prototype/trim/name": {
+		"category": "not_es3"
+	},
+	"built-ins/String/raw/length": {
+		"category": "not_es3"
+	},
+	"built-ins/String/raw/name": {
+		"category": "not_es3"
+	},
+	"built-ins/String/raw/nextkey-is-symbol-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/String/raw/raw": {
+		"category": "not_es3"
+	},
+	"built-ins/String/raw/return-empty-string-from-empty-array-length": {
+		"category": "not_es3"
+	},
+	"built-ins/String/raw/return-empty-string-if-length-is-negative-infinity": {
+		"category": "not_es3"
+	},
+	"built-ins/String/raw/return-empty-string-if-length-is-not-defined": {
+		"category": "not_es3"
+	},
+	"built-ins/String/raw/return-empty-string-if-length-is-undefined": {
+		"category": "not_es3"
+	},
+	"built-ins/String/raw/return-empty-string-if-length-is-zero-NaN": {
+		"category": "not_es3"
+	},
+	"built-ins/String/raw/return-empty-string-if-length-is-zero-boolean": {
+		"category": "not_es3"
+	},
+	"built-ins/String/raw/return-empty-string-if-length-is-zero-null": {
+		"category": "not_es3"
+	},
+	"built-ins/String/raw/return-empty-string-if-length-is-zero-or-less-number": {
+		"category": "not_es3"
+	},
+	"built-ins/String/raw/return-empty-string-if-length-is-zero-or-less-string": {
+		"category": "not_es3"
+	},
+	"built-ins/String/raw/return-the-string-value": {
+		"category": "not_es3"
+	},
+	"built-ins/String/raw/return-the-string-value-from-template": {
+		"category": "not_es3"
+	},
+	"built-ins/String/raw/returns-abrupt-from-next-key": {
+		"category": "not_es3"
+	},
+	"built-ins/String/raw/returns-abrupt-from-next-key-toString": {
+		"category": "not_es3"
+	},
+	"built-ins/String/raw/returns-abrupt-from-substitution": {
+		"category": "not_es3"
+	},
+	"built-ins/String/raw/returns-abrupt-from-substitution-symbol": {
+		"category": "not_es3"
+	},
+	"built-ins/String/raw/special-characters": {
+		"category": "not_es3"
+	},
+	"built-ins/String/raw/substitutions-are-appended-on-same-index": {
+		"category": "not_es3"
+	},
+	"built-ins/String/raw/substitutions-are-limited-to-template-raw-length": {
+		"category": "not_es3"
+	},
+	"built-ins/String/raw/template-length-is-symbol-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/String/raw/template-length-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/String/raw/template-raw-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/String/raw/template-substitutions-are-appended-on-same-index": {
+		"category": "not_es3"
+	},
+	"built-ins/String/raw/zero-literal-segments": {
+		"category": "not_es3"
+	},
+	"built-ins/String/symbol-string-coercion": {
+		"category": "not_es3"
+	},
+	"built-ins/StringIteratorPrototype/Symbol.toStringTag": {
+		"category": "not_es3"
+	},
+	"built-ins/StringIteratorPrototype/ancestry": {
+		"category": "not_es3"
+	},
+	"built-ins/StringIteratorPrototype/next/length": {
+		"category": "not_es3"
+	},
+	"built-ins/StringIteratorPrototype/next/name": {
+		"category": "not_es3"
+	},
+	"built-ins/StringIteratorPrototype/next/next-iteration": {
+		"category": "not_es3"
+	},
+	"built-ins/StringIteratorPrototype/next/next-iteration-surrogate-pairs": {
+		"category": "not_es3"
+	},
+	"built-ins/StringIteratorPrototype/next/next-missing-internal-slots": {
+		"category": "not_es3"
+	},
+	"built-ins/Symbol/auto-boxing-non-strict": {
+		"category": "not_es3"
+	},
+	"built-ins/Symbol/constructor": {
+		"category": "not_es3"
+	},
+	"built-ins/Symbol/for/length": {
+		"category": "not_es3"
+	},
+	"built-ins/Symbol/for/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Symbol/hasInstance/prop-desc": {
+		"category": "not_es3"
+	},
+	"built-ins/Symbol/isConcatSpreadable/prop-desc": {
+		"category": "not_es3"
+	},
+	"built-ins/Symbol/iterator/prop-desc": {
+		"category": "not_es3"
+	},
+	"built-ins/Symbol/keyFor/length": {
+		"category": "not_es3"
+	},
+	"built-ins/Symbol/keyFor/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Symbol/match/prop-desc": {
+		"category": "not_es3"
+	},
+	"built-ins/Symbol/prototype/Symbol.toPrimitive/length": {
+		"category": "not_es3"
+	},
+	"built-ins/Symbol/prototype/Symbol.toPrimitive/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Symbol/prototype/Symbol.toPrimitive/prop-desc": {
+		"category": "not_es3"
+	},
+	"built-ins/Symbol/prototype/Symbol.toPrimitive/this-val-non-obj": {
+		"category": "not_es3"
+	},
+	"built-ins/Symbol/prototype/Symbol.toPrimitive/this-val-obj-non-symbol-wrapper": {
+		"category": "not_es3"
+	},
+	"built-ins/Symbol/prototype/Symbol.toPrimitive/this-val-obj-symbol-wrapper": {
+		"category": "not_es3"
+	},
+	"built-ins/Symbol/prototype/Symbol.toPrimitive/this-val-symbol": {
+		"category": "not_es3"
+	},
+	"built-ins/Symbol/prototype/Symbol.toStringTag": {
+		"category": "not_es3"
+	},
+	"built-ins/Symbol/prototype/intrinsic": {
+		"category": "not_es3"
+	},
+	"built-ins/Symbol/prototype/toString/length": {
+		"category": "not_es3"
+	},
+	"built-ins/Symbol/prototype/toString/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Symbol/prototype/toString/toString": {
+		"category": "not_es3"
+	},
+	"built-ins/Symbol/prototype/toString/toString-default-attributes-non-strict": {
+		"category": "not_es3"
+	},
+	"built-ins/Symbol/prototype/valueOf/length": {
+		"category": "not_es3"
+	},
+	"built-ins/Symbol/prototype/valueOf/name": {
+		"category": "not_es3"
+	},
+	"built-ins/Symbol/replace/prop-desc": {
+		"category": "not_es3"
+	},
+	"built-ins/Symbol/search/prop-desc": {
+		"category": "not_es3"
+	},
+	"built-ins/Symbol/species/basic": {
+		"category": "not_es3"
+	},
+	"built-ins/Symbol/species/builtin-getter-name": {
+		"category": "not_es3"
+	},
+	"built-ins/Symbol/species/subclassing": {
+		"category": "not_es3"
+	},
+	"built-ins/Symbol/split/prop-desc": {
+		"category": "not_es3"
+	},
+	"built-ins/Symbol/toPrimitive/prop-desc": {
+		"category": "not_es3"
+	},
+	"built-ins/Symbol/toStringTag/prop-desc": {
+		"category": "not_es3"
+	},
+	"built-ins/Symbol/unscopables/prop-desc": {
 		"category": "not_es3"
 	},
 	"built-ins/TypedArray/Symbol.species/length": {
@@ -6068,6 +19052,15 @@
 	"built-ins/TypedArray/from/this-is-not-constructor": {
 		"category": "not_es3"
 	},
+	"built-ins/TypedArray/invoked": {
+		"category": "not_es3"
+	},
+	"built-ins/TypedArray/length": {
+		"category": "not_es3"
+	},
+	"built-ins/TypedArray/name": {
+		"category": "not_es3"
+	},
 	"built-ins/TypedArray/of/invoked-as-func": {
 		"category": "not_es3"
 	},
@@ -6086,13 +19079,10 @@
 	"built-ins/TypedArray/of/this-is-not-constructor": {
 		"category": "not_es3"
 	},
+	"built-ins/TypedArray/prototype": {
+		"category": "not_es3"
+	},
 	"built-ins/TypedArray/prototype/Symbol.iterator": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArray/prototype/constructor": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArray/prototype/toString": {
 		"category": "not_es3"
 	},
 	"built-ins/TypedArray/prototype/Symbol.toStringTag/invoked-as-accessor": {
@@ -6198,6 +19188,9 @@
 		"category": "not_es3"
 	},
 	"built-ins/TypedArray/prototype/byteOffset/this-is-not-object": {
+		"category": "not_es3"
+	},
+	"built-ins/TypedArray/prototype/constructor": {
 		"category": "not_es3"
 	},
 	"built-ins/TypedArray/prototype/copyWithin/invoked-as-func": {
@@ -6554,6 +19547,9 @@
 	"built-ins/TypedArray/prototype/toLocaleString/prop-desc": {
 		"category": "not_es3"
 	},
+	"built-ins/TypedArray/prototype/toString": {
+		"category": "not_es3"
+	},
 	"built-ins/TypedArray/prototype/toString/length": {
 		"category": "not_es3"
 	},
@@ -6576,252 +19572,6 @@
 		"category": "not_es3"
 	},
 	"built-ins/TypedArray/prototype/values/prop-desc": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/buffer-arg-bufferbyteoffset-throws-from-modulo-element-size": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/buffer-arg-byteoffset-is-negative-throws": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/buffer-arg-byteoffset-is-negative-zero": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/buffer-arg-byteoffset-is-symbol-throws": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/buffer-arg-byteoffset-throws-from-modulo-element-size": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/buffer-arg-byteoffset-to-number-throws": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/buffer-arg-custom-proto-access-throws": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/buffer-arg-defined-length-and-offset": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/buffer-arg-defined-length": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/buffer-arg-defined-negative-length": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/buffer-arg-defined-offset": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/buffer-arg-excessive-length-throws": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/buffer-arg-excessive-offset-throws": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/buffer-arg-invoked-with-undefined-newtarget": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/buffer-arg-is-referenced": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/buffer-arg-length-access-throws": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/buffer-arg-length-is-symbol-throws": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/buffer-arg-returns-new-instance": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/buffer-arg-use-custom-proto-if-object": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/buffer-arg-use-default-proto-if-custom-proto-is-not-object": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/length-arg-custom-proto-access-throws": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/length-arg-is-float-throws-rangeerror": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/length-arg-is-infinity-throws-rangeerror": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/length-arg-is-nan-throws-rangeerror": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/length-arg-is-negative-number-throws-rangeerror": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/length-arg-is-not-valid-buffer-size-throws-rangeerror": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/length-arg-is-symbol-throws": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/length-arg-is-undefined-throws": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/length-arg-minus-signal-zero": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/length-arg-returns-object": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/length-arg-undefined-newtarget-throws": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/length-arg-use-custom-proto-if-object": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/length-arg-use-default-proto-if-custom-proto-is-not-object": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/no-args-custom-proto-access-throws": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/no-args-returns-object": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/no-args-undefined-newtarget-throws": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/no-args-use-custom-proto-if-object": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/no-args-use-default-proto-if-custom-proto-is-not-object": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/object-arg-as-array-returns": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/object-arg-as-generator-iterable-returns": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/object-arg-custom-proto-access-throws": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/object-arg-iterating-throws": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/object-arg-iterator-not-callable-throws": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/object-arg-iterator-throws": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/object-arg-length-excessive-throws": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/object-arg-length-is-symbol-throws": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/object-arg-length-throws": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/object-arg-returns": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/object-arg-throws-from-property": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/object-arg-throws-setting-obj-to-primitive-typeerror": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/object-arg-throws-setting-obj-to-primitive": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/object-arg-throws-setting-obj-tostring": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/object-arg-throws-setting-obj-valueof-typeerror": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/object-arg-throws-setting-obj-valueof": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/object-arg-throws-setting-property": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/object-arg-throws-setting-symbol-property": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/object-arg-undefined-newtarget-throws": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/object-arg-use-custom-proto-if-object": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/object-arg-use-default-proto-if-custom-proto-is-not-object": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/typedarray-arg-custom-proto-access-throws": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/typedarray-arg-other-ctor-buffer-ctor-access-throws": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/typedarray-arg-other-ctor-buffer-ctor-custom-species": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/typedarray-arg-other-ctor-buffer-ctor-not-object-throws": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/typedarray-arg-other-ctor-buffer-ctor-species-access-throws": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/typedarray-arg-other-ctor-buffer-ctor-species-not-ctor-throws": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/typedarray-arg-other-ctor-buffer-ctor-species-null": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/typedarray-arg-other-ctor-buffer-ctor-species-prototype-throws": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/typedarray-arg-other-ctor-buffer-ctor-species-undefined": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/typedarray-arg-other-ctor-returns-new-typedarray": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/typedarray-arg-returns-new-instance": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/typedarray-arg-same-ctor-buffer-ctor-access-throws": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/typedarray-arg-same-ctor-buffer-ctor-species-custom": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/typedarray-arg-same-ctor-buffer-ctor-species-not-ctor": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/typedarray-arg-same-ctor-buffer-ctor-species-null": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/typedarray-arg-same-ctor-buffer-ctor-species-prototype-throws": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/typedarray-arg-same-ctor-buffer-ctor-species-throws": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/typedarray-arg-same-ctor-buffer-ctor-species-undefined": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/typedarray-arg-same-ctor-buffer-ctor-value-not-obj-throws": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/typedarray-arg-same-ctor-returns-new-cloned-typedarray": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/typedarray-arg-undefined-newtarget-throws": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/typedarray-arg-use-custom-proto-if-object": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/typedarray-arg-use-default-proto-if-custom-proto-is-not-object": {
 		"category": "not_es3"
 	},
 	"built-ins/TypedArrays/Float32Array/BYTES_PER_ELEMENT": {
@@ -7094,16 +19844,76 @@
 	"built-ins/TypedArrays/Uint8ClampedArray/prototype/proto": {
 		"category": "not_es3"
 	},
+	"built-ins/TypedArrays/buffer-arg-bufferbyteoffset-throws-from-modulo-element-size": {
+		"category": "not_es3"
+	},
+	"built-ins/TypedArrays/buffer-arg-byteoffset-is-negative-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/TypedArrays/buffer-arg-byteoffset-is-negative-zero": {
+		"category": "not_es3"
+	},
+	"built-ins/TypedArrays/buffer-arg-byteoffset-is-symbol-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/TypedArrays/buffer-arg-byteoffset-throws-from-modulo-element-size": {
+		"category": "not_es3"
+	},
+	"built-ins/TypedArrays/buffer-arg-byteoffset-to-number-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/TypedArrays/buffer-arg-custom-proto-access-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/TypedArrays/buffer-arg-defined-length": {
+		"category": "not_es3"
+	},
+	"built-ins/TypedArrays/buffer-arg-defined-length-and-offset": {
+		"category": "not_es3"
+	},
+	"built-ins/TypedArrays/buffer-arg-defined-negative-length": {
+		"category": "not_es3"
+	},
+	"built-ins/TypedArrays/buffer-arg-defined-offset": {
+		"category": "not_es3"
+	},
+	"built-ins/TypedArrays/buffer-arg-excessive-length-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/TypedArrays/buffer-arg-excessive-offset-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/TypedArrays/buffer-arg-invoked-with-undefined-newtarget": {
+		"category": "not_es3"
+	},
+	"built-ins/TypedArrays/buffer-arg-is-referenced": {
+		"category": "not_es3"
+	},
+	"built-ins/TypedArrays/buffer-arg-length-access-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/TypedArrays/buffer-arg-length-is-symbol-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/TypedArrays/buffer-arg-returns-new-instance": {
+		"category": "not_es3"
+	},
+	"built-ins/TypedArrays/buffer-arg-use-custom-proto-if-object": {
+		"category": "not_es3"
+	},
+	"built-ins/TypedArrays/buffer-arg-use-default-proto-if-custom-proto-is-not-object": {
+		"category": "not_es3"
+	},
 	"built-ins/TypedArrays/from/arylk-get-length-error": {
 		"category": "not_es3"
 	},
 	"built-ins/TypedArrays/from/arylk-to-length-error": {
 		"category": "not_es3"
 	},
-	"built-ins/TypedArrays/from/custom-ctor-does-not-instantiate-ta-throws": {
+	"built-ins/TypedArrays/from/custom-ctor": {
 		"category": "not_es3"
 	},
-	"built-ins/TypedArrays/from/custom-ctor": {
+	"built-ins/TypedArrays/from/custom-ctor-does-not-instantiate-ta-throws": {
 		"category": "not_es3"
 	},
 	"built-ins/TypedArrays/from/inherited": {
@@ -7175,16 +19985,133 @@
 	"built-ins/TypedArrays/from/this-is-not-constructor": {
 		"category": "not_es3"
 	},
+	"built-ins/TypedArrays/length-arg-custom-proto-access-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/TypedArrays/length-arg-is-float-throws-rangeerror": {
+		"category": "not_es3"
+	},
+	"built-ins/TypedArrays/length-arg-is-infinity-throws-rangeerror": {
+		"category": "not_es3"
+	},
+	"built-ins/TypedArrays/length-arg-is-nan-throws-rangeerror": {
+		"category": "not_es3"
+	},
+	"built-ins/TypedArrays/length-arg-is-negative-number-throws-rangeerror": {
+		"category": "not_es3"
+	},
+	"built-ins/TypedArrays/length-arg-is-not-valid-buffer-size-throws-rangeerror": {
+		"category": "not_es3"
+	},
+	"built-ins/TypedArrays/length-arg-is-symbol-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/TypedArrays/length-arg-is-undefined-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/TypedArrays/length-arg-minus-signal-zero": {
+		"category": "not_es3"
+	},
+	"built-ins/TypedArrays/length-arg-returns-object": {
+		"category": "not_es3"
+	},
+	"built-ins/TypedArrays/length-arg-undefined-newtarget-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/TypedArrays/length-arg-use-custom-proto-if-object": {
+		"category": "not_es3"
+	},
+	"built-ins/TypedArrays/length-arg-use-default-proto-if-custom-proto-is-not-object": {
+		"category": "not_es3"
+	},
+	"built-ins/TypedArrays/no-args-custom-proto-access-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/TypedArrays/no-args-returns-object": {
+		"category": "not_es3"
+	},
+	"built-ins/TypedArrays/no-args-undefined-newtarget-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/TypedArrays/no-args-use-custom-proto-if-object": {
+		"category": "not_es3"
+	},
+	"built-ins/TypedArrays/no-args-use-default-proto-if-custom-proto-is-not-object": {
+		"category": "not_es3"
+	},
+	"built-ins/TypedArrays/object-arg-as-array-returns": {
+		"category": "not_es3"
+	},
+	"built-ins/TypedArrays/object-arg-as-generator-iterable-returns": {
+		"category": "not_es3"
+	},
+	"built-ins/TypedArrays/object-arg-custom-proto-access-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/TypedArrays/object-arg-iterating-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/TypedArrays/object-arg-iterator-not-callable-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/TypedArrays/object-arg-iterator-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/TypedArrays/object-arg-length-excessive-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/TypedArrays/object-arg-length-is-symbol-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/TypedArrays/object-arg-length-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/TypedArrays/object-arg-returns": {
+		"category": "not_es3"
+	},
+	"built-ins/TypedArrays/object-arg-throws-from-property": {
+		"category": "not_es3"
+	},
+	"built-ins/TypedArrays/object-arg-throws-setting-obj-to-primitive": {
+		"category": "not_es3"
+	},
+	"built-ins/TypedArrays/object-arg-throws-setting-obj-to-primitive-typeerror": {
+		"category": "not_es3"
+	},
+	"built-ins/TypedArrays/object-arg-throws-setting-obj-tostring": {
+		"category": "not_es3"
+	},
+	"built-ins/TypedArrays/object-arg-throws-setting-obj-valueof": {
+		"category": "not_es3"
+	},
+	"built-ins/TypedArrays/object-arg-throws-setting-obj-valueof-typeerror": {
+		"category": "not_es3"
+	},
+	"built-ins/TypedArrays/object-arg-throws-setting-property": {
+		"category": "not_es3"
+	},
+	"built-ins/TypedArrays/object-arg-throws-setting-symbol-property": {
+		"category": "not_es3"
+	},
+	"built-ins/TypedArrays/object-arg-undefined-newtarget-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/TypedArrays/object-arg-use-custom-proto-if-object": {
+		"category": "not_es3"
+	},
+	"built-ins/TypedArrays/object-arg-use-default-proto-if-custom-proto-is-not-object": {
+		"category": "not_es3"
+	},
 	"built-ins/TypedArrays/of/argument-is-symbol-throws": {
 		"category": "not_es3"
 	},
 	"built-ins/TypedArrays/of/argument-number-value-throws": {
 		"category": "not_es3"
 	},
-	"built-ins/TypedArrays/of/custom-ctor-does-not-instantiate-ta-throws": {
+	"built-ins/TypedArrays/of/custom-ctor": {
 		"category": "not_es3"
 	},
-	"built-ins/TypedArrays/of/custom-ctor": {
+	"built-ins/TypedArrays/of/custom-ctor-does-not-instantiate-ta-throws": {
 		"category": "not_es3"
 	},
 	"built-ins/TypedArrays/of/inherited": {
@@ -7196,6 +20123,9 @@
 	"built-ins/TypedArrays/of/nan-conversion": {
 		"category": "not_es3"
 	},
+	"built-ins/TypedArrays/of/new-instance": {
+		"category": "not_es3"
+	},
 	"built-ins/TypedArrays/of/new-instance-empty": {
 		"category": "not_es3"
 	},
@@ -7203,9 +20133,6 @@
 		"category": "not_es3"
 	},
 	"built-ins/TypedArrays/of/new-instance-using-custom-ctor": {
-		"category": "not_es3"
-	},
-	"built-ins/TypedArrays/of/new-instance": {
 		"category": "not_es3"
 	},
 	"built-ins/TypedArrays/of/this-is-not-constructor": {
@@ -7301,593 +20228,2363 @@
 	"built-ins/TypedArrays/prototype/values/inherited": {
 		"category": "not_es3"
 	},
-	"built-ins/Symbol/auto-boxing-non-strict": {
+	"built-ins/TypedArrays/typedarray-arg-custom-proto-access-throws": {
 		"category": "not_es3"
 	},
-	"built-ins/Symbol/constructor": {
+	"built-ins/TypedArrays/typedarray-arg-other-ctor-buffer-ctor-access-throws": {
 		"category": "not_es3"
 	},
-	"built-ins/Symbol/for/length": {
+	"built-ins/TypedArrays/typedarray-arg-other-ctor-buffer-ctor-custom-species": {
 		"category": "not_es3"
 	},
-	"built-ins/Symbol/for/name": {
+	"built-ins/TypedArrays/typedarray-arg-other-ctor-buffer-ctor-not-object-throws": {
 		"category": "not_es3"
 	},
-	"built-ins/Symbol/hasInstance/prop-desc": {
+	"built-ins/TypedArrays/typedarray-arg-other-ctor-buffer-ctor-species-access-throws": {
 		"category": "not_es3"
 	},
-	"built-ins/Symbol/isConcatSpreadable/prop-desc": {
+	"built-ins/TypedArrays/typedarray-arg-other-ctor-buffer-ctor-species-not-ctor-throws": {
 		"category": "not_es3"
 	},
-	"built-ins/Symbol/iterator/prop-desc": {
+	"built-ins/TypedArrays/typedarray-arg-other-ctor-buffer-ctor-species-null": {
 		"category": "not_es3"
 	},
-	"built-ins/Symbol/keyFor/length": {
+	"built-ins/TypedArrays/typedarray-arg-other-ctor-buffer-ctor-species-prototype-throws": {
 		"category": "not_es3"
 	},
-	"built-ins/Symbol/keyFor/name": {
+	"built-ins/TypedArrays/typedarray-arg-other-ctor-buffer-ctor-species-undefined": {
 		"category": "not_es3"
 	},
-	"built-ins/Symbol/match/prop-desc": {
+	"built-ins/TypedArrays/typedarray-arg-other-ctor-returns-new-typedarray": {
 		"category": "not_es3"
 	},
-	"built-ins/Symbol/prototype/Symbol.toStringTag": {
+	"built-ins/TypedArrays/typedarray-arg-returns-new-instance": {
 		"category": "not_es3"
 	},
-	"built-ins/Symbol/prototype/intrinsic": {
+	"built-ins/TypedArrays/typedarray-arg-same-ctor-buffer-ctor-access-throws": {
 		"category": "not_es3"
 	},
-	"built-ins/Symbol/prototype/Symbol.toPrimitive/length": {
+	"built-ins/TypedArrays/typedarray-arg-same-ctor-buffer-ctor-species-custom": {
 		"category": "not_es3"
 	},
-	"built-ins/Symbol/prototype/Symbol.toPrimitive/name": {
+	"built-ins/TypedArrays/typedarray-arg-same-ctor-buffer-ctor-species-not-ctor": {
 		"category": "not_es3"
 	},
-	"built-ins/Symbol/prototype/Symbol.toPrimitive/prop-desc": {
+	"built-ins/TypedArrays/typedarray-arg-same-ctor-buffer-ctor-species-null": {
 		"category": "not_es3"
 	},
-	"built-ins/Symbol/prototype/Symbol.toPrimitive/this-val-non-obj": {
+	"built-ins/TypedArrays/typedarray-arg-same-ctor-buffer-ctor-species-prototype-throws": {
 		"category": "not_es3"
 	},
-	"built-ins/Symbol/prototype/Symbol.toPrimitive/this-val-obj-non-symbol-wrapper": {
+	"built-ins/TypedArrays/typedarray-arg-same-ctor-buffer-ctor-species-throws": {
 		"category": "not_es3"
 	},
-	"built-ins/Symbol/prototype/Symbol.toPrimitive/this-val-obj-symbol-wrapper": {
+	"built-ins/TypedArrays/typedarray-arg-same-ctor-buffer-ctor-species-undefined": {
 		"category": "not_es3"
 	},
-	"built-ins/Symbol/prototype/Symbol.toPrimitive/this-val-symbol": {
+	"built-ins/TypedArrays/typedarray-arg-same-ctor-buffer-ctor-value-not-obj-throws": {
 		"category": "not_es3"
 	},
-	"built-ins/Symbol/prototype/toString/length": {
+	"built-ins/TypedArrays/typedarray-arg-same-ctor-returns-new-cloned-typedarray": {
 		"category": "not_es3"
 	},
-	"built-ins/Symbol/prototype/toString/name": {
+	"built-ins/TypedArrays/typedarray-arg-undefined-newtarget-throws": {
 		"category": "not_es3"
 	},
-	"built-ins/Symbol/prototype/toString/toString-default-attributes-non-strict": {
+	"built-ins/TypedArrays/typedarray-arg-use-custom-proto-if-object": {
 		"category": "not_es3"
 	},
-	"built-ins/Symbol/prototype/toString/toString": {
+	"built-ins/TypedArrays/typedarray-arg-use-default-proto-if-custom-proto-is-not-object": {
 		"category": "not_es3"
 	},
-	"built-ins/Symbol/prototype/valueOf/length": {
+	"built-ins/WeakMap/constructor": {
 		"category": "not_es3"
 	},
-	"built-ins/Symbol/prototype/valueOf/name": {
+	"built-ins/WeakMap/empty-iterable": {
 		"category": "not_es3"
 	},
-	"built-ins/Symbol/replace/prop-desc": {
+	"built-ins/WeakMap/get-set-method-failure": {
 		"category": "not_es3"
 	},
-	"built-ins/Symbol/search/prop-desc": {
+	"built-ins/WeakMap/iterable": {
 		"category": "not_es3"
 	},
-	"built-ins/Symbol/species/basic": {
+	"built-ins/WeakMap/iterable-failure": {
 		"category": "not_es3"
 	},
-	"built-ins/Symbol/species/builtin-getter-name": {
+	"built-ins/WeakMap/iterator-close-after-set-failure": {
 		"category": "not_es3"
 	},
-	"built-ins/Symbol/species/subclassing": {
+	"built-ins/WeakMap/iterator-item-first-entry-returns-abrupt": {
 		"category": "not_es3"
 	},
-	"built-ins/Symbol/split/prop-desc": {
+	"built-ins/WeakMap/iterator-item-second-entry-returns-abrupt": {
 		"category": "not_es3"
 	},
-	"built-ins/Symbol/toPrimitive/prop-desc": {
+	"built-ins/WeakMap/iterator-items-are-not-object": {
 		"category": "not_es3"
 	},
-	"built-ins/Symbol/toStringTag/prop-desc": {
+	"built-ins/WeakMap/iterator-items-are-not-object-close-iterator": {
 		"category": "not_es3"
 	},
-	"built-ins/Symbol/unscopables/prop-desc": {
+	"built-ins/WeakMap/iterator-next-failure": {
 		"category": "not_es3"
 	},
-	"built-ins/StringIteratorPrototype/Symbol.toStringTag": {
+	"built-ins/WeakMap/iterator-value-failure": {
 		"category": "not_es3"
 	},
-	"built-ins/StringIteratorPrototype/ancestry": {
+	"built-ins/WeakMap/length": {
 		"category": "not_es3"
 	},
-	"built-ins/StringIteratorPrototype/next/length": {
+	"built-ins/WeakMap/name": {
 		"category": "not_es3"
 	},
-	"built-ins/StringIteratorPrototype/next/name": {
+	"built-ins/WeakMap/no-iterable": {
 		"category": "not_es3"
 	},
-	"built-ins/StringIteratorPrototype/next/next-iteration-surrogate-pairs": {
+	"built-ins/WeakMap/properties-of-map-instances": {
 		"category": "not_es3"
 	},
-	"built-ins/StringIteratorPrototype/next/next-iteration": {
+	"built-ins/WeakMap/properties-of-the-weakmap-prototype-object": {
 		"category": "not_es3"
 	},
-	"built-ins/StringIteratorPrototype/next/next-missing-internal-slots": {
+	"built-ins/WeakMap/prototype-of-weakmap": {
 		"category": "not_es3"
 	},
-	"built-ins/String/raw/length": {
+	"built-ins/WeakMap/prototype/Symbol.toStringTag": {
 		"category": "not_es3"
 	},
-	"built-ins/String/raw/name": {
+	"built-ins/WeakMap/prototype/constructor": {
 		"category": "not_es3"
 	},
-	"built-ins/String/raw/nextkey-is-symbol-throws": {
+	"built-ins/WeakMap/prototype/delete/delete": {
 		"category": "not_es3"
 	},
-	"built-ins/String/raw/raw": {
+	"built-ins/WeakMap/prototype/delete/delete-entry": {
 		"category": "not_es3"
 	},
-	"built-ins/String/raw/return-empty-string-from-empty-array-length": {
+	"built-ins/WeakMap/prototype/delete/delete-entry-initial-iterable": {
 		"category": "not_es3"
 	},
-	"built-ins/String/raw/return-empty-string-if-length-is-negative-infinity": {
+	"built-ins/WeakMap/prototype/delete/does-not-have-weakmapdata-internal-slot-array": {
 		"category": "not_es3"
 	},
-	"built-ins/String/raw/return-empty-string-if-length-is-not-defined": {
+	"built-ins/WeakMap/prototype/delete/does-not-have-weakmapdata-internal-slot-map": {
 		"category": "not_es3"
 	},
-	"built-ins/String/raw/return-empty-string-if-length-is-undefined": {
+	"built-ins/WeakMap/prototype/delete/does-not-have-weakmapdata-internal-slot-object": {
 		"category": "not_es3"
 	},
-	"built-ins/String/raw/return-empty-string-if-length-is-zero-NaN": {
+	"built-ins/WeakMap/prototype/delete/does-not-have-weakmapdata-internal-slot-set": {
 		"category": "not_es3"
 	},
-	"built-ins/String/raw/return-empty-string-if-length-is-zero-boolean": {
+	"built-ins/WeakMap/prototype/delete/does-not-have-weakmapdata-internal-slot-weakmap-prototype": {
 		"category": "not_es3"
 	},
-	"built-ins/String/raw/return-empty-string-if-length-is-zero-null": {
+	"built-ins/WeakMap/prototype/delete/length": {
 		"category": "not_es3"
 	},
-	"built-ins/String/raw/return-empty-string-if-length-is-zero-or-less-number": {
+	"built-ins/WeakMap/prototype/delete/name": {
 		"category": "not_es3"
 	},
-	"built-ins/String/raw/return-empty-string-if-length-is-zero-or-less-string": {
+	"built-ins/WeakMap/prototype/delete/returns-false-value-is-not-object": {
 		"category": "not_es3"
 	},
-	"built-ins/String/raw/return-the-string-value-from-template": {
+	"built-ins/WeakMap/prototype/delete/returns-false-when-delete-is-noop": {
 		"category": "not_es3"
 	},
-	"built-ins/String/raw/return-the-string-value": {
+	"built-ins/WeakMap/prototype/delete/this-not-object-throw-boolean": {
 		"category": "not_es3"
 	},
-	"built-ins/String/raw/returns-abrupt-from-next-key-toString": {
+	"built-ins/WeakMap/prototype/delete/this-not-object-throw-null": {
 		"category": "not_es3"
 	},
-	"built-ins/String/raw/returns-abrupt-from-next-key": {
+	"built-ins/WeakMap/prototype/delete/this-not-object-throw-number": {
 		"category": "not_es3"
 	},
-	"built-ins/String/raw/returns-abrupt-from-substitution-symbol": {
+	"built-ins/WeakMap/prototype/delete/this-not-object-throw-string": {
 		"category": "not_es3"
 	},
-	"built-ins/String/raw/returns-abrupt-from-substitution": {
+	"built-ins/WeakMap/prototype/delete/this-not-object-throw-symbol": {
 		"category": "not_es3"
 	},
-	"built-ins/String/raw/special-characters": {
+	"built-ins/WeakMap/prototype/delete/this-not-object-throw-undefined": {
 		"category": "not_es3"
 	},
-	"built-ins/String/raw/substitutions-are-appended-on-same-index": {
+	"built-ins/WeakMap/prototype/get/does-not-have-weakmapdata-internal-slot": {
 		"category": "not_es3"
 	},
-	"built-ins/String/raw/substitutions-are-limited-to-template-raw-length": {
+	"built-ins/WeakMap/prototype/get/does-not-have-weakmapdata-internal-slot-map": {
 		"category": "not_es3"
 	},
-	"built-ins/String/raw/template-length-is-symbol-throws": {
+	"built-ins/WeakMap/prototype/get/does-not-have-weakmapdata-internal-slot-set": {
 		"category": "not_es3"
 	},
-	"built-ins/String/raw/template-length-throws": {
+	"built-ins/WeakMap/prototype/get/get": {
 		"category": "not_es3"
 	},
-	"built-ins/String/raw/template-raw-throws": {
+	"built-ins/WeakMap/prototype/get/length": {
 		"category": "not_es3"
 	},
-	"built-ins/String/raw/template-substitutions-are-appended-on-same-index": {
+	"built-ins/WeakMap/prototype/get/name": {
 		"category": "not_es3"
 	},
-	"built-ins/String/raw/zero-literal-segments": {
+	"built-ins/WeakMap/prototype/get/returns-undefined": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/split/cstm-split-get-err": {
+	"built-ins/WeakMap/prototype/get/returns-undefined-key-is-not-object": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/split/cstm-split-invocation": {
+	"built-ins/WeakMap/prototype/get/returns-value": {
 		"category": "not_es3"
 	},
-	"annexB/built-ins/String/prototype/anchor/B.2.3.2": {
-		"category": "bad_test"
+	"built-ins/WeakMap/prototype/get/this-not-object-throw": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakMap/prototype/has/does-not-have-weakmapdata-internal-slot-array": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakMap/prototype/has/does-not-have-weakmapdata-internal-slot-map": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakMap/prototype/has/does-not-have-weakmapdata-internal-slot-object": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakMap/prototype/has/does-not-have-weakmapdata-internal-slot-set": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakMap/prototype/has/does-not-have-weakmapdata-internal-slot-weakmap-prototype": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakMap/prototype/has/has": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakMap/prototype/has/length": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakMap/prototype/has/name": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakMap/prototype/has/returns-false-when-value-is-not-object": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakMap/prototype/has/returns-false-when-value-not-present": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakMap/prototype/has/returns-true-when-value-present": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakMap/prototype/has/this-not-object-throw-boolean": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakMap/prototype/has/this-not-object-throw-null": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakMap/prototype/has/this-not-object-throw-number": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakMap/prototype/has/this-not-object-throw-string": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakMap/prototype/has/this-not-object-throw-symbol": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakMap/prototype/has/this-not-object-throw-undefined": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakMap/prototype/prototype-attributes": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakMap/prototype/set/adds-element": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakMap/prototype/set/does-not-have-weakmapdata-internal-slot-array": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakMap/prototype/set/does-not-have-weakmapdata-internal-slot-map": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakMap/prototype/set/does-not-have-weakmapdata-internal-slot-object": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakMap/prototype/set/does-not-have-weakmapdata-internal-slot-set": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakMap/prototype/set/does-not-have-weakmapdata-internal-slot-weakmap-prototype": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakMap/prototype/set/key-not-object-throw": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakMap/prototype/set/length": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakMap/prototype/set/name": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakMap/prototype/set/returns-this": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakMap/prototype/set/returns-this-when-ignoring-duplicate": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakMap/prototype/set/set": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakMap/prototype/set/this-not-object-throw-boolean": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakMap/prototype/set/this-not-object-throw-null": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakMap/prototype/set/this-not-object-throw-number": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakMap/prototype/set/this-not-object-throw-string": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakMap/prototype/set/this-not-object-throw-symbol": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakMap/prototype/set/this-not-object-throw-undefined": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakMap/set-not-callable-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakMap/undefined-newtarget": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakMap/weakmap": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/add-not-callable-throws": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/constructor": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/empty-iterable": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/get-add-method-failure": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/iterable": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/iterable-failure": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/iterator-close-after-add-failure": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/iterator-next-failure": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/iterator-value-failure": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/length": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/name": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/no-iterable": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/properties-of-the-weakset-prototype-object": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/prototype-of-weakset": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/prototype/Symbol.toStringTag": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/prototype/add/add": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/prototype/add/adds-element": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/prototype/add/does-not-have-weaksetdata-internal-slot-array": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/prototype/add/does-not-have-weaksetdata-internal-slot-map": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/prototype/add/does-not-have-weaksetdata-internal-slot-object": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/prototype/add/does-not-have-weaksetdata-internal-slot-set": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/prototype/add/does-not-have-weaksetdata-internal-slot-weakset-prototype": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/prototype/add/length": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/prototype/add/name": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/prototype/add/returns-this": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/prototype/add/returns-this-when-ignoring-duplicate": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/prototype/add/this-not-object-throw-boolean": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/prototype/add/this-not-object-throw-null": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/prototype/add/this-not-object-throw-number": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/prototype/add/this-not-object-throw-string": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/prototype/add/this-not-object-throw-symbol": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/prototype/add/this-not-object-throw-undefined": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/prototype/add/value-not-object-throw": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/prototype/constructor/weakset-prototype-constructor": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/prototype/constructor/weakset-prototype-constructor-intrinsic": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/prototype/delete/delete": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/prototype/delete/delete-entry": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/prototype/delete/delete-entry-initial-iterable": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/prototype/delete/does-not-have-weaksetdata-internal-slot-array": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/prototype/delete/does-not-have-weaksetdata-internal-slot-map": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/prototype/delete/does-not-have-weaksetdata-internal-slot-object": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/prototype/delete/does-not-have-weaksetdata-internal-slot-set": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/prototype/delete/does-not-have-weaksetdata-internal-slot-weakset-prototype": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/prototype/delete/length": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/prototype/delete/name": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/prototype/delete/returns-false-value-is-not-object": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/prototype/delete/returns-false-when-delete-is-noop": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/prototype/delete/this-not-object-throw-boolean": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/prototype/delete/this-not-object-throw-null": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/prototype/delete/this-not-object-throw-number": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/prototype/delete/this-not-object-throw-string": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/prototype/delete/this-not-object-throw-symbol": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/prototype/delete/this-not-object-throw-undefined": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/prototype/has/does-not-have-weaksetdata-internal-slot-array": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/prototype/has/does-not-have-weaksetdata-internal-slot-map": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/prototype/has/does-not-have-weaksetdata-internal-slot-object": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/prototype/has/does-not-have-weaksetdata-internal-slot-set": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/prototype/has/does-not-have-weaksetdata-internal-slot-weakset-prototype": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/prototype/has/has": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/prototype/has/length": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/prototype/has/name": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/prototype/has/returns-false-when-value-is-not-object": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/prototype/has/returns-false-when-value-not-present": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/prototype/has/returns-true-when-value-present": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/prototype/has/this-not-object-throw-boolean": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/prototype/has/this-not-object-throw-null": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/prototype/has/this-not-object-throw-number": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/prototype/has/this-not-object-throw-string": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/prototype/has/this-not-object-throw-symbol": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/prototype/has/this-not-object-throw-undefined": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/prototype/prototype-attributes": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/symbol-disallowed-as-weakset-key": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/undefined-newtarget": {
+		"category": "not_es3"
+	},
+	"built-ins/WeakSet/weakset": {
+		"category": "not_es3"
+	},
+	"language/arguments-object/10.6-11-b-1": {
+		"category": "not_es3"
 	},
-	"annexB/built-ins/String/prototype/anchor/length": {
-		"category": "bad_test"
+	"language/arguments-object/10.6-12-2": {
+		"category": "not_es3"
+	},
+	"language/arguments-object/10.6-13-a-1": {
+		"category": ""
+	},
+	"language/arguments-object/10.6-13-a-2": {
+		"category": ""
+	},
+	"language/arguments-object/10.6-13-a-3": {
+		"category": ""
+	},
+	"language/arguments-object/10.6-13-c-2-s": {
+		"category": "tbd"
+	},
+	"language/arguments-object/10.6-14-c-1-s": {
+		"category": ""
+	},
+	"language/arguments-object/10.6-5-1": {
+		"category": ""
+	},
+	"language/arguments-object/10.6-6-1": {
+		"category": "tbd"
+	},
+	"language/arguments-object/10.6-6-2": {
+		"category": "tbd"
+	},
+	"language/arguments-object/10.6-7-1": {
+		"category": ""
+	},
+	"language/arguments-object/S10.6_A2": {
+		"category": ""
+	},
+	"language/arguments-object/S10.6_A3_T1": {
+		"category": ""
+	},
+	"language/arguments-object/S10.6_A4": {
+		"category": ""
+	},
+	"language/arguments-object/S10.6_A5_T1": {
+		"category": ""
+	},
+	"language/arguments-object/mapped/Symbol.iterator": {
+		"category": "not_es3"
+	},
+	"language/arguments-object/mapped/mapped-arguments-nonconfigurable-1": {
+		"category": "tbd"
+	},
+	"language/arguments-object/mapped/mapped-arguments-nonconfigurable-2": {
+		"category": "tbd"
+	},
+	"language/arguments-object/mapped/mapped-arguments-nonconfigurable-3": {
+		"category": "tbd"
+	},
+	"language/arguments-object/mapped/mapped-arguments-nonconfigurable-4": {
+		"category": "tbd"
+	},
+	"language/arguments-object/mapped/mapped-arguments-nonconfigurable-delete-1": {
+		"category": "tbd"
+	},
+	"language/arguments-object/mapped/mapped-arguments-nonconfigurable-delete-2": {
+		"category": "tbd"
+	},
+	"language/arguments-object/mapped/mapped-arguments-nonconfigurable-delete-3": {
+		"category": "tbd"
+	},
+	"language/arguments-object/mapped/mapped-arguments-nonconfigurable-delete-4": {
+		"category": "tbd"
+	},
+	"language/arguments-object/mapped/mapped-arguments-nonconfigurable-nonwritable-1": {
+		"category": "tbd"
+	},
+	"language/arguments-object/mapped/mapped-arguments-nonconfigurable-nonwritable-2": {
+		"category": "tbd"
+	},
+	"language/arguments-object/mapped/mapped-arguments-nonconfigurable-nonwritable-3": {
+		"category": "tbd"
+	},
+	"language/arguments-object/mapped/mapped-arguments-nonconfigurable-nonwritable-4": {
+		"category": "tbd"
+	},
+	"language/arguments-object/mapped/mapped-arguments-nonconfigurable-nonwritable-5": {
+		"category": "tbd"
+	},
+	"language/arguments-object/mapped/mapped-arguments-nonconfigurable-strict-delete-1": {
+		"category": "tbd"
+	},
+	"language/arguments-object/mapped/mapped-arguments-nonconfigurable-strict-delete-2": {
+		"category": "tbd"
+	},
+	"language/arguments-object/mapped/mapped-arguments-nonconfigurable-strict-delete-3": {
+		"category": "tbd"
+	},
+	"language/arguments-object/mapped/mapped-arguments-nonconfigurable-strict-delete-4": {
+		"category": "tbd"
+	},
+	"language/arguments-object/mapped/mapped-arguments-nonwritable-nonconfigurable-1": {
+		"category": "tbd"
+	},
+	"language/arguments-object/mapped/mapped-arguments-nonwritable-nonconfigurable-2": {
+		"category": "tbd"
+	},
+	"language/arguments-object/mapped/mapped-arguments-nonwritable-nonconfigurable-3": {
+		"category": "tbd"
+	},
+	"language/arguments-object/mapped/mapped-arguments-nonwritable-nonconfigurable-4": {
+		"category": "tbd"
+	},
+	"language/arguments-object/unmapped/Symbol.iterator": {
+		"category": "not_es3"
+	},
+	"language/block-scope/leave/finally-block-let-declaration-only-shadows-outer-parameter-value-1": {
+		"category": "not_es3"
+	},
+	"language/block-scope/leave/finally-block-let-declaration-only-shadows-outer-parameter-value-2": {
+		"category": "not_es3"
+	},
+	"language/block-scope/leave/for-loop-block-let-declaration-only-shadows-outer-parameter-value-1": {
+		"category": "not_es3"
+	},
+	"language/block-scope/leave/for-loop-block-let-declaration-only-shadows-outer-parameter-value-2": {
+		"category": "not_es3"
+	},
+	"language/block-scope/leave/nested-block-let-declaration-only-shadows-outer-parameter-value-1": {
+		"category": "not_es3"
+	},
+	"language/block-scope/leave/nested-block-let-declaration-only-shadows-outer-parameter-value-2": {
+		"category": "not_es3"
+	},
+	"language/block-scope/leave/outermost-binding-updated-in-catch-block-nested-block-let-declaration-unseen-outside-of-block": {
+		"category": "not_es3"
+	},
+	"language/block-scope/leave/try-block-let-declaration-only-shadows-outer-parameter-value-1": {
+		"category": "not_es3"
+	},
+	"language/block-scope/leave/try-block-let-declaration-only-shadows-outer-parameter-value-2": {
+		"category": "not_es3"
+	},
+	"language/block-scope/leave/verify-context-in-finally-block": {
+		"category": "not_es3"
+	},
+	"language/block-scope/leave/verify-context-in-for-loop-block": {
+		"category": "not_es3"
+	},
+	"language/block-scope/leave/verify-context-in-labelled-block": {
+		"category": "not_es3"
+	},
+	"language/block-scope/leave/verify-context-in-try-block": {
+		"category": "not_es3"
+	},
+	"language/block-scope/leave/x-after-break-to-label": {
+		"category": "not_es3"
+	},
+	"language/block-scope/leave/x-before-continue": {
+		"category": "not_es3"
+	},
+	"language/block-scope/return-from/block-const": {
+		"category": "not_es3"
+	},
+	"language/block-scope/return-from/block-let": {
+		"category": "not_es3"
+	},
+	"language/block-scope/shadowing/catch-parameter-shadowing-let-declaration": {
+		"category": "not_es3"
+	},
+	"language/block-scope/shadowing/const-declaration-shadowing-catch-parameter": {
+		"category": "not_es3"
+	},
+	"language/block-scope/shadowing/const-declarations-shadowing-parameter-name-let-const-and-var-variables": {
+		"category": "not_es3"
+	},
+	"language/block-scope/shadowing/dynamic-lookup-from-closure": {
+		"category": "not_es3"
+	},
+	"language/block-scope/shadowing/dynamic-lookup-in-and-through-block-contexts": {
+		"category": "not_es3"
+	},
+	"language/block-scope/shadowing/let-declaration-shadowing-catch-parameter": {
+		"category": "not_es3"
+	},
+	"language/block-scope/shadowing/let-declarations-shadowing-parameter-name-let-const-and-var": {
+		"category": "not_es3"
+	},
+	"language/block-scope/shadowing/lookup-from-closure": {
+		"category": "not_es3"
+	},
+	"language/block-scope/shadowing/lookup-in-and-through-block-contexts": {
+		"category": "not_es3"
+	},
+	"language/block-scope/shadowing/parameter-name-shadowing-parameter-name-let-const-and-var": {
+		"category": "not_es3"
+	},
+	"language/block-scope/syntax/for-in/acquire-properties-from-array": {
+		"category": "not_es3"
+	},
+	"language/block-scope/syntax/for-in/acquire-properties-from-object": {
+		"category": "not_es3"
+	},
+	"language/block-scope/syntax/for-in/mixed-values-in-iteration": {
+		"category": "not_es3"
+	},
+	"language/block-scope/syntax/redeclaration-in-block/attempt-to-redeclare-function-declaration-with-function-declaration": {
+		"category": "tbd"
+	},
+	"language/block-scope/syntax/redeclaration-in-block/attempt-to-redeclare-function-declaration-with-var": {
+		"category": "tbd"
+	},
+	"language/block-scope/syntax/redeclaration-in-block/attempt-to-redeclare-var-with-function-declaration": {
+		"category": "tbd"
+	},
+	"language/comments/S7.4_A5": {
+		"category": ""
+	},
+	"language/computed-property-names/basics/number": {
+		"category": "not_es3"
+	},
+	"language/computed-property-names/basics/string": {
+		"category": "not_es3"
+	},
+	"language/computed-property-names/basics/symbol": {
+		"category": "not_es3"
+	},
+	"language/computed-property-names/class/accessor/getter": {
+		"category": "not_es3"
+	},
+	"language/computed-property-names/class/accessor/getter-duplicates": {
+		"category": "not_es3"
+	},
+	"language/computed-property-names/class/accessor/setter": {
+		"category": "not_es3"
+	},
+	"language/computed-property-names/class/accessor/setter-duplicates": {
+		"category": "not_es3"
+	},
+	"language/computed-property-names/class/method/constructor": {
+		"category": "not_es3"
+	},
+	"language/computed-property-names/class/method/constructor-can-be-generator": {
+		"category": "not_es3"
+	},
+	"language/computed-property-names/class/method/constructor-can-be-getter": {
+		"category": "not_es3"
+	},
+	"language/computed-property-names/class/method/constructor-can-be-setter": {
+		"category": "not_es3"
+	},
+	"language/computed-property-names/class/method/constructor-duplicate-1": {
+		"category": "not_es3"
+	},
+	"language/computed-property-names/class/method/constructor-duplicate-2": {
+		"category": "not_es3"
+	},
+	"language/computed-property-names/class/method/constructor-duplicate-3": {
+		"category": "not_es3"
+	},
+	"language/computed-property-names/class/method/generator": {
+		"category": "not_es3"
+	},
+	"language/computed-property-names/class/method/number": {
+		"category": "not_es3"
+	},
+	"language/computed-property-names/class/method/string": {
+		"category": "not_es3"
+	},
+	"language/computed-property-names/class/method/symbol": {
+		"category": "not_es3"
+	},
+	"language/computed-property-names/class/static/generator-constructor": {
+		"category": "not_es3"
+	},
+	"language/computed-property-names/class/static/generator-prototype": {
+		"category": "not_es3"
+	},
+	"language/computed-property-names/class/static/getter-constructor": {
+		"category": "not_es3"
+	},
+	"language/computed-property-names/class/static/getter-prototype": {
+		"category": "not_es3"
+	},
+	"language/computed-property-names/class/static/method-constructor": {
+		"category": "not_es3"
+	},
+	"language/computed-property-names/class/static/method-number": {
+		"category": "not_es3"
+	},
+	"language/computed-property-names/class/static/method-prototype": {
+		"category": "not_es3"
+	},
+	"language/computed-property-names/class/static/method-string": {
+		"category": "not_es3"
+	},
+	"language/computed-property-names/class/static/method-symbol": {
+		"category": "not_es3"
+	},
+	"language/computed-property-names/class/static/setter-constructor": {
+		"category": "not_es3"
+	},
+	"language/computed-property-names/class/static/setter-prototype": {
+		"category": "not_es3"
+	},
+	"language/computed-property-names/object/accessor/getter": {
+		"category": "not_es3"
+	},
+	"language/computed-property-names/object/accessor/getter-duplicates": {
+		"category": "not_es3"
+	},
+	"language/computed-property-names/object/accessor/getter-super": {
+		"category": "not_es3"
+	},
+	"language/computed-property-names/object/accessor/setter": {
+		"category": "not_es3"
+	},
+	"language/computed-property-names/object/accessor/setter-duplicates": {
+		"category": "not_es3"
 	},
-	"annexB/built-ins/String/prototype/anchor/name": {
-		"category": "bad_test"
+	"language/computed-property-names/object/accessor/setter-super": {
+		"category": "not_es3"
+	},
+	"language/computed-property-names/object/method/generator": {
+		"category": "not_es3"
+	},
+	"language/computed-property-names/object/method/number": {
+		"category": "not_es3"
+	},
+	"language/computed-property-names/object/method/string": {
+		"category": "not_es3"
 	},
-	"annexB/built-ins/String/prototype/big/B.2.3.3": {
-		"category": "bad_test"
+	"language/computed-property-names/object/method/super": {
+		"category": "not_es3"
 	},
-	"annexB/built-ins/String/prototype/big/length": {
-		"category": "bad_test"
+	"language/computed-property-names/object/method/symbol": {
+		"category": "not_es3"
 	},
-	"annexB/built-ins/String/prototype/big/name": {
-		"category": "bad_test"
+	"language/computed-property-names/object/property/number-duplicates": {
+		"category": "not_es3"
 	},
-	"annexB/built-ins/String/prototype/blink/B.2.3.4": {
-		"category": "bad_test"
+	"language/computed-property-names/to-name-side-effects/class": {
+		"category": "not_es3"
 	},
-	"annexB/built-ins/String/prototype/blink/length": {
-		"category": "bad_test"
+	"language/computed-property-names/to-name-side-effects/numbers-class": {
+		"category": "not_es3"
 	},
-	"annexB/built-ins/String/prototype/blink/name": {
-		"category": "bad_test"
+	"language/computed-property-names/to-name-side-effects/numbers-object": {
+		"category": "not_es3"
 	},
-	"annexB/built-ins/String/prototype/bold/B.2.3.5": {
-		"category": "bad_test"
+	"language/computed-property-names/to-name-side-effects/object": {
+		"category": "not_es3"
 	},
-	"annexB/built-ins/String/prototype/bold/length": {
-		"category": "bad_test"
+	"language/default-parameters/call-define-values": {
+		"category": "not_es3"
 	},
-	"annexB/built-ins/String/prototype/bold/name": {
-		"category": "bad_test"
+	"language/default-parameters/call-returns-reference-error": {
+		"category": "not_es3"
 	},
-	"annexB/built-ins/String/prototype/fixed/B.2.3.6": {
-		"category": "bad_test"
+	"language/default-parameters/class-definitions": {
+		"category": "not_es3"
 	},
-	"annexB/built-ins/String/prototype/fixed/length": {
-		"category": "bad_test"
+	"language/default-parameters/default-parameters-always-provide-unmapped-arguments": {
+		"category": "not_es3"
 	},
-	"annexB/built-ins/String/prototype/fixed/name": {
-		"category": "bad_test"
+	"language/default-parameters/destructuring": {
+		"category": "not_es3"
 	},
-	"annexB/built-ins/String/prototype/fontcolor/B.2.3.7": {
-		"category": "bad_test"
+	"language/default-parameters/function-constructor": {
+		"category": "not_es3"
 	},
-	"annexB/built-ins/String/prototype/fontcolor/length": {
-		"category": "bad_test"
+	"language/default-parameters/function-length": {
+		"category": "not_es3"
 	},
-	"annexB/built-ins/String/prototype/fontcolor/name": {
-		"category": "bad_test"
+	"language/default-parameters/generators": {
+		"category": "not_es3"
 	},
-	"annexB/built-ins/String/prototype/fontsize/B.2.3.8": {
-		"category": "bad_test"
+	"language/default-parameters/method-definitions": {
+		"category": "not_es3"
 	},
-	"annexB/built-ins/String/prototype/fontsize/length": {
-		"category": "bad_test"
+	"language/default-parameters/param-ref-initialized": {
+		"category": "not_es3"
 	},
-	"annexB/built-ins/String/prototype/fontsize/name": {
-		"category": "bad_test"
+	"language/default-parameters/param-ref-uninitialized": {
+		"category": "not_es3"
 	},
-	"annexB/built-ins/String/prototype/italics/B.2.3.9": {
-		"category": "bad_test"
+	"language/default-parameters/replace-default-values": {
+		"category": "not_es3"
 	},
-	"annexB/built-ins/String/prototype/italics/length": {
-		"category": "bad_test"
+	"language/default-parameters/returns-abrupt-from-property-value": {
+		"category": "not_es3"
 	},
-	"annexB/built-ins/String/prototype/italics/name": {
-		"category": "bad_test"
+	"language/default-parameters/scope": {
+		"category": "not_es3"
 	},
-	"annexB/built-ins/String/prototype/link/B.2.3.10": {
-		"category": "bad_test"
+	"language/default-parameters/variable-initial-value-as-parameter": {
+		"category": "not_es3"
 	},
-	"annexB/built-ins/String/prototype/link/length": {
-		"category": "bad_test"
+	"language/default-parameters/variable-initial-value-undefined": {
+		"category": "not_es3"
 	},
-	"annexB/built-ins/String/prototype/link/name": {
-		"category": "bad_test"
+	"language/destructuring/binding/initialization-requires-object-coercible-null": {
+		"category": "not_es3"
 	},
-	"annexB/built-ins/String/prototype/small/B.2.3.11": {
-		"category": "bad_test"
+	"language/destructuring/binding/initialization-requires-object-coercible-undefined": {
+		"category": "not_es3"
 	},
-	"annexB/built-ins/String/prototype/small/length": {
-		"category": "bad_test"
+	"language/destructuring/binding/initialization-returns-normal-completion-for-empty-objects": {
+		"category": "not_es3"
 	},
-	"annexB/built-ins/String/prototype/small/name": {
-		"category": "bad_test"
+	"language/destructuring/binding/syntax/array-elements-with-initializer": {
+		"category": "not_es3"
 	},
-	"annexB/built-ins/String/prototype/strike/B.2.3.12": {
-		"category": "bad_test"
+	"language/destructuring/binding/syntax/array-elements-with-object-patterns": {
+		"category": "not_es3"
 	},
-	"annexB/built-ins/String/prototype/strike/length": {
-		"category": "bad_test"
+	"language/destructuring/binding/syntax/array-elements-without-initializer": {
+		"category": "not_es3"
 	},
-	"annexB/built-ins/String/prototype/strike/name": {
-		"category": "bad_test"
+	"language/destructuring/binding/syntax/array-pattern-with-elisions": {
+		"category": "not_es3"
 	},
-	"annexB/built-ins/String/prototype/sub/B.2.3.13": {
-		"category": "bad_test"
+	"language/destructuring/binding/syntax/array-pattern-with-no-elements": {
+		"category": "not_es3"
 	},
-	"annexB/built-ins/String/prototype/sub/length": {
-		"category": "bad_test"
+	"language/destructuring/binding/syntax/array-rest-elements": {
+		"category": "not_es3"
 	},
-	"annexB/built-ins/String/prototype/sub/name": {
-		"category": "bad_test"
+	"language/destructuring/binding/syntax/object-pattern-with-no-property-list": {
+		"category": "not_es3"
 	},
-	"annexB/built-ins/String/prototype/sup/B.2.3.14": {
-		"category": "bad_test"
+	"language/destructuring/binding/syntax/property-list-bindings-elements": {
+		"category": "not_es3"
 	},
-	"annexB/built-ins/String/prototype/sup/length": {
-		"category": "bad_test"
+	"language/destructuring/binding/syntax/property-list-followed-by-a-single-comma": {
+		"category": "not_es3"
 	},
-	"annexB/built-ins/String/prototype/sup/name": {
-		"category": "bad_test"
+	"language/destructuring/binding/syntax/property-list-single-name-bindings": {
+		"category": "not_es3"
 	},
-	"built-ins/String/symbol-string-coercion": {
+	"language/destructuring/binding/syntax/property-list-with-property-list": {
 		"category": "not_es3"
 	},
-	"built-ins/String/fromCodePoint/argument-is-Symbol": {
+	"language/destructuring/binding/syntax/recursive-array-and-object-patterns": {
 		"category": "not_es3"
 	},
-	"built-ins/String/fromCodePoint/argument-is-not-integer": {
+	"language/directive-prologue/10.1.1-11-s": {
 		"category": "not_es3"
 	},
-	"built-ins/String/fromCodePoint/argument-not-coercible": {
+	"language/directive-prologue/10.1.1-14-s": {
 		"category": "not_es3"
 	},
-	"built-ins/String/fromCodePoint/arguments-is-empty": {
+	"language/directive-prologue/10.1.1-15-s": {
 		"category": "not_es3"
 	},
-	"built-ins/String/fromCodePoint/fromCodePoint": {
+	"language/directive-prologue/10.1.1-16-s": {
 		"category": "not_es3"
 	},
-	"built-ins/String/fromCodePoint/length": {
+	"language/directive-prologue/10.1.1-17-s": {
 		"category": "not_es3"
 	},
-	"built-ins/String/fromCodePoint/name": {
+	"language/directive-prologue/10.1.1-18-s": {
 		"category": "not_es3"
 	},
-	"built-ins/String/fromCodePoint/number-is-out-of-range": {
+	"language/directive-prologue/10.1.1-19-s": {
 		"category": "not_es3"
 	},
-	"built-ins/String/fromCodePoint/return-string-value": {
+	"language/directive-prologue/10.1.1-2-s": {
 		"category": "not_es3"
 	},
-	"built-ins/String/fromCodePoint/to-number-conversions": {
+	"language/directive-prologue/10.1.1-22-s": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/Symbol.iterator/length": {
+	"language/directive-prologue/10.1.1-25-s": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/Symbol.iterator/name": {
+	"language/directive-prologue/10.1.1-26-s": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/Symbol.iterator/prop-desc": {
+	"language/directive-prologue/10.1.1-27-s": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/Symbol.iterator/this-val-non-obj-coercible": {
+	"language/directive-prologue/10.1.1-28-s": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/Symbol.iterator/this-val-to-str-err": {
+	"language/directive-prologue/10.1.1-2gs": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/codePointAt/return-abrupt-from-symbol-pos-to-integer": {
+	"language/directive-prologue/10.1.1-30-s": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/codePointAt/return-abrupt-from-this-as-symbol": {
+	"language/directive-prologue/10.1.1-5-s": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/codePointAt/return-code-unit-coerced-position": {
+	"language/directive-prologue/10.1.1-5gs": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/codePointAt/return-first-code-unit": {
+	"language/directive-prologue/10.1.1-8-s": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/codePointAt/return-single-code-unit": {
+	"language/directive-prologue/10.1.1-8gs": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/codePointAt/return-utf16-decode": {
+	"language/directive-prologue/14.1-1-s": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/codePointAt/returns-undefined-on-position-equal-or-more-than-size": {
+	"language/directive-prologue/14.1-10-s": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/codePointAt/returns-undefined-on-position-less-than-zero": {
+	"language/directive-prologue/14.1-11-s": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/codePointAt/codePointAt": {
+	"language/directive-prologue/14.1-12-s": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/codePointAt/length": {
+	"language/directive-prologue/14.1-13-s": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/codePointAt/name": {
+	"language/directive-prologue/14.1-14-s": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/codePointAt/return-abrupt-from-object-pos-to-integer": {
+	"language/directive-prologue/14.1-15-s": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/codePointAt/return-abrupt-from-this": {
+	"language/directive-prologue/14.1-2-s": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/endsWith/String.prototype.endsWith_Fail": {
+	"language/directive-prologue/14.1-4-s": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/endsWith/String.prototype.endsWith_Fail_2": {
+	"language/directive-prologue/14.1-4gs": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/endsWith/String.prototype.endsWith_Success": {
+	"language/directive-prologue/14.1-5gs": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/endsWith/String.prototype.endsWith_Success_2": {
+	"language/directive-prologue/14.1-8-s": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/endsWith/String.prototype.endsWith_Success_3": {
+	"language/directive-prologue/14.1-9-s": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/endsWith/String.prototype.endsWith_Success_4": {
+	"language/eval-code/10.4.2-1-5": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/endsWith/coerced-values-of-position": {
+	"language/eval-code/10.4.2-3-c-1-s": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/endsWith/endsWith": {
+	"language/eval-code/10.4.2.1-4-s": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/endsWith/length": {
+	"language/eval-code/S10.4.2.1_A1": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/endsWith/name": {
+	"language/eval-code/non-definable-function-with-function": {
+		"category": "tbd"
+	},
+	"language/eval-code/non-definable-function-with-variable": {
+		"category": "tbd"
+	},
+	"language/eval-code/non-definable-global-function": {
+		"category": "tbd"
+	},
+	"language/eval-code/non-definable-global-generator": {
 		"category": "not_es3"
+	},
+	"language/expressions/addition/S11.6.1_A1": {
+		"category": ""
+	},
+	"language/expressions/array/11.1.4-0": {
+		"category": ""
+	},
+	"language/expressions/array/S11.1.4_A1.2": {
+		"category": ""
+	},
+	"language/expressions/array/S11.1.4_A1.4": {
+		"category": ""
 	},
-	"built-ins/String/prototype/endsWith/return-abrupt-from-position-as-symbol": {
+	"language/expressions/array/S11.1.4_A1.5": {
+		"category": ""
+	},
+	"language/expressions/array/S11.1.4_A1.6": {
+		"category": ""
+	},
+	"language/expressions/array/S11.1.4_A1.7": {
+		"category": ""
+	},
+	"language/expressions/arrow-function/ArrowFunction_restricted-properties": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/endsWith/return-abrupt-from-position": {
+	"language/expressions/arrow-function/arrow/binding-tests-1": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/endsWith/return-abrupt-from-searchstring-as-symbol": {
+	"language/expressions/arrow-function/arrow/binding-tests-2": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/endsWith/return-abrupt-from-searchstring-regexp-test": {
+	"language/expressions/arrow-function/arrow/binding-tests-3": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/endsWith/return-abrupt-from-searchstring": {
+	"language/expressions/arrow-function/arrow/capturing-closure-variables-1": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/endsWith/return-abrupt-from-this-as-symbol": {
+	"language/expressions/arrow-function/arrow/capturing-closure-variables-2": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/endsWith/return-abrupt-from-this": {
+	"language/expressions/arrow-function/arrow/concisebody-lookahead-assignmentexpression-1": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/endsWith/return-false-if-search-start-is-less-than-zero": {
+	"language/expressions/arrow-function/arrow/concisebody-lookahead-assignmentexpression-2": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/endsWith/return-true-if-searchstring-is-empty": {
+	"language/expressions/arrow-function/cannot-override-this-with-thisArg": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/endsWith/searchstring-found-with-position": {
+	"language/expressions/arrow-function/empty-function-body-returns-undefined": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/endsWith/searchstring-found-without-position": {
+	"language/expressions/arrow-function/expression-body-implicit-return": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/endsWith/searchstring-not-found-with-position": {
+	"language/expressions/arrow-function/lexical-arguments": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/endsWith/searchstring-not-found-without-position": {
+	"language/expressions/arrow-function/lexical-bindings-overriden-by-formal-parameters-non-strict": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/includes/String.prototype.includes_FailBadLocation": {
+	"language/expressions/arrow-function/lexical-new.target": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/includes/String.prototype.includes_FailLocation": {
+	"language/expressions/arrow-function/lexical-new.target-closure-returned": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/includes/String.prototype.includes_FailMissingLetter": {
+	"language/expressions/arrow-function/lexical-super-call-from-within-constructor": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/includes/String.prototype.includes_Success": {
+	"language/expressions/arrow-function/lexical-super-property": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/includes/String.prototype.includes_SuccessNoLocation": {
+	"language/expressions/arrow-function/lexical-super-property-from-within-constructor": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/includes/String.prototype.includes_lengthProp": {
+	"language/expressions/arrow-function/lexical-supercall-from-immediately-invoked-arrow": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/includes/coerced-values-of-position": {
+	"language/expressions/arrow-function/lexical-this": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/includes/includes": {
+	"language/expressions/arrow-function/low-precedence-expression-body-no-parens": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/includes/length": {
+	"language/expressions/arrow-function/non-strict": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/includes/name": {
+	"language/expressions/arrow-function/object-literal-return-requires-body-parens": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/includes/return-abrupt-from-position-as-symbol": {
+	"language/expressions/arrow-function/prototype-rules": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/includes/return-abrupt-from-position": {
+	"language/expressions/arrow-function/statement-body-requires-braces-must-return-explicitly": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/includes/return-abrupt-from-searchstring-as-symbol": {
+	"language/expressions/arrow-function/statement-body-requires-braces-must-return-explicitly-missing": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/includes/return-abrupt-from-searchstring-regexp-test": {
+	"language/expressions/arrow-function/syntax/arrowparameters-bindingidentifier-arguments": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/includes/return-abrupt-from-searchstring": {
+	"language/expressions/arrow-function/syntax/arrowparameters-bindingidentifier-concisebody-assignmentexpression": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/includes/return-abrupt-from-this-as-symbol": {
+	"language/expressions/arrow-function/syntax/arrowparameters-bindingidentifier-concisebody-functionbody": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/includes/return-abrupt-from-this": {
+	"language/expressions/arrow-function/syntax/arrowparameters-bindingidentifier-eval": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/includes/return-false-with-out-of-bounds-position": {
+	"language/expressions/arrow-function/syntax/arrowparameters-bindingidentifier-lineterminator-concisebody-assignmentexpression": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/includes/return-true-if-searchstring-is-empty": {
+	"language/expressions/arrow-function/syntax/arrowparameters-bindingidentifier-lineterminator-concisebody-functionbody": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/includes/searchstring-found-with-position": {
+	"language/expressions/arrow-function/syntax/arrowparameters-bindingidentifier-yield": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/includes/searchstring-found-without-position": {
+	"language/expressions/arrow-function/syntax/arrowparameters-cover-concisebody-assignmentexpression": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/includes/searchstring-not-found-with-position": {
+	"language/expressions/arrow-function/syntax/arrowparameters-cover-concisebody-functionbody": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/includes/searchstring-not-found-without-position": {
+	"language/expressions/arrow-function/syntax/arrowparameters-cover-formalparameters-arguments": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/indexOf/S15.5.4.7_A1_T12": {
+	"language/expressions/arrow-function/syntax/arrowparameters-cover-formalparameters-eval": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/lastIndexOf/S15.5.4.8_A1_T12": {
+	"language/expressions/arrow-function/syntax/arrowparameters-cover-formalparameters-yield": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/match/cstm-matcher-get-err": {
+	"language/expressions/arrow-function/syntax/arrowparameters-cover-includes-rest-concisebody-functionbody": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/match/cstm-matcher-invocation": {
+	"language/expressions/arrow-function/syntax/arrowparameters-cover-initialize-1": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/match/invoke-builtin-match": {
+	"language/expressions/arrow-function/syntax/arrowparameters-cover-initialize-2": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/search/cstm-search-get-err": {
+	"language/expressions/arrow-function/syntax/arrowparameters-cover-lineterminator-concisebody-assignmentexpression": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/search/cstm-search-invocation": {
+	"language/expressions/arrow-function/syntax/arrowparameters-cover-lineterminator-concisebody-functionbody": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/search/invoke-builtin-search-searcher-undef": {
+	"language/expressions/arrow-function/syntax/arrowparameters-cover-rest-concisebody-functionbody": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/search/invoke-builtin-search": {
+	"language/expressions/arrow-function/syntax/arrowparameters-cover-rest-lineterminator-concisebody-functionbody": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/replace/cstm-replace-get-err": {
+	"language/expressions/arrow-function/syntax/variations": {
 		"category": "not_es3"
 	},
-	"built-ins/String/prototype/replace/cstm-replace-invocation": {
+	"language/expressions/arrow-function/throw-new": {
 		"category": "not_es3"
+	},
+	"language/expressions/assignment/11.13.1-4-1": {
+		"category": "tbd"
+	},
+	"language/expressions/assignment/8.12.5-3-b_1": {
+		"category": "tbd"
+	},
+	"language/expressions/assignment/8.12.5-3-b_2": {
+		"category": "tbd"
+	},
+	"language/expressions/assignment/8.12.5-5-b_1": {
+		"category": "tbd"
+	},
+	"language/expressions/assignment/S11.13.1_A1": {
+		"category": ""
 	},
-	"language/statements/function/S13.2.1_A1_T1": {
+	"language/expressions/assignment/S11.13.1_A5_T1": {
 		"category": "by_design"
+	},
+	"language/expressions/assignment/S11.13.1_A5_T2": {
+		"category": "by_design"
+	},
+	"language/expressions/assignment/S11.13.1_A5_T3": {
+		"category": "by_design"
+	},
+	"language/expressions/assignment/S11.13.1_A5_T4": {
+		"category": "by_design"
+	},
+	"language/expressions/assignment/S11.13.1_A6_T1": {
+		"category": "by_design"
+	},
+	"language/expressions/assignment/S11.13.1_A6_T2": {
+		"category": "by_design"
+	},
+	"language/expressions/assignment/S11.13.1_A6_T3": {
+		"category": "by_design"
+	},
+	"language/expressions/assignment/S11.13.1_A7_T1": {
+		"category": "by_design"
+	},
+	"language/expressions/assignment/S11.13.1_A7_T2": {
+		"category": "by_design"
+	},
+	"language/expressions/assignment/destructuring/array-elem-elision": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-elem-init-assignment": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-elem-init-evaluation": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-elem-init-fn-name-arrow": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-elem-init-fn-name-class": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-elem-init-fn-name-cover": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-elem-init-fn-name-fn": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-elem-init-fn-name-gen": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-elem-init-in": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-elem-init-let": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-elem-init-order": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-elem-init-simple-no-strict": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-elem-init-yield-expr": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-elem-init-yield-ident-valid": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-elem-nested-array": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-elem-nested-array-invalid": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-elem-nested-array-null": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-elem-nested-array-undefined": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-elem-nested-array-undefined-hole": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-elem-nested-array-undefined-own": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-elem-nested-array-yield-expr": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-elem-nested-array-yield-ident-valid": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-elem-nested-obj": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-elem-nested-obj-invalid": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-elem-nested-obj-null": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-elem-nested-obj-undefined": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-elem-nested-obj-undefined-hole": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-elem-nested-obj-undefined-own": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-elem-nested-obj-yield-expr": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-elem-nested-obj-yield-ident-valid": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-elem-put-const": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-elem-put-let": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-elem-put-prop-ref": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-elem-put-prop-ref-no-get": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-elem-put-prop-ref-user-err": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-elem-put-unresolvable-no-strict": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-elem-target-identifier": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-elem-target-simple-no-strict": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-elem-target-yield-expr": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-elem-target-yield-valid": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-empty": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-iteration": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-rest-after-element": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-rest-after-elision": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-rest-elision": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-rest-iteration": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-rest-nested-array": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-rest-nested-array-null": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-rest-nested-array-undefined": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-rest-nested-array-undefined-hole": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-rest-nested-array-undefined-own": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-rest-nested-array-yield-expr": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-rest-nested-array-yield-ident-valid": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-rest-nested-obj": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-rest-nested-obj-null": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-rest-nested-obj-undefined": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-rest-nested-obj-undefined-hole": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-rest-nested-obj-undefined-own": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-rest-nested-obj-yield-expr": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-rest-nested-obj-yield-ident-valid": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-rest-put-const": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-rest-put-let": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-rest-put-prop-ref": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-rest-put-prop-ref-no-get": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-rest-put-prop-ref-user-err": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-rest-put-unresolvable-no-strict": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-rest-yield-expr": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-rest-yield-ident-valid": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/array-sparse": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/obj-id-identifier-resolution": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/obj-id-identifier-yield-ident-valid": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/obj-id-init-assignment": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/obj-id-init-evaluation": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/obj-id-init-fn-name-arrow": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/obj-id-init-fn-name-class": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/obj-id-init-fn-name-cover": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/obj-id-init-fn-name-fn": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/obj-id-init-fn-name-gen": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/obj-id-init-in": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/obj-id-init-let": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/obj-id-init-order": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/obj-id-init-simple-no-strict": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/obj-id-init-yield-expr": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/obj-id-init-yield-ident-valid": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/obj-id-put-const": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/obj-id-put-let": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/obj-id-put-unresolvable-no-strict": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/obj-id-simple-no-strict": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/obj-prop-elem-init-assignment": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/obj-prop-elem-init-evaluation": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/obj-prop-elem-init-fn-name-arrow": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/obj-prop-elem-init-fn-name-class": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/obj-prop-elem-init-fn-name-cover": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/obj-prop-elem-init-fn-name-fn": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/obj-prop-elem-init-fn-name-gen": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/obj-prop-elem-init-in": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/obj-prop-elem-init-let": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/obj-prop-elem-init-yield-expr": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/obj-prop-elem-init-yield-ident-valid": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/obj-prop-elem-target-yield-expr": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/obj-prop-elem-target-yield-ident-valid": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/obj-prop-identifier-resolution": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/obj-prop-name-evaluation": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/obj-prop-name-evaluation-error": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/obj-prop-nested-array": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/obj-prop-nested-array-invalid": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/obj-prop-nested-array-null": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/obj-prop-nested-array-undefined": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/obj-prop-nested-array-undefined-own": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/obj-prop-nested-array-yield-expr": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/obj-prop-nested-array-yield-ident-valid": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/obj-prop-nested-obj": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/obj-prop-nested-obj-invalid": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/obj-prop-nested-obj-null": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/obj-prop-nested-obj-undefined": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/obj-prop-nested-obj-undefined-own": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/obj-prop-nested-obj-yield-expr": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/obj-prop-nested-obj-yield-ident-valid": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/obj-prop-put-const": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/obj-prop-put-let": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/obj-prop-put-order": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/obj-prop-put-prop-ref": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/obj-prop-put-prop-ref-no-get": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/obj-prop-put-prop-ref-user-err": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/obj-prop-put-unresolvable-no-strict": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/destructuring/object-empty": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/fn-name-arrow": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/fn-name-class": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/fn-name-cover": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/fn-name-fn": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/fn-name-gen": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/fn-name-lhs-cover": {
+		"category": "not_es3"
+	},
+	"language/expressions/assignment/fn-name-lhs-member": {
+		"category": "not_es3"
+	},
+	"language/expressions/bitwise-and/S11.10.1_A1": {
+		"category": ""
+	},
+	"language/expressions/bitwise-not/S11.4.8_A1": {
+		"category": ""
+	},
+	"language/expressions/bitwise-or/S11.10.3_A1": {
+		"category": ""
+	},
+	"language/expressions/bitwise-xor/S11.10.2_A1": {
+		"category": ""
+	},
+	"language/expressions/call/11.2.3-3_3": {
+		"category": "tbd"
+	},
+	"language/expressions/call/11.2.3-3_4": {
+		"category": "tbd"
+	},
+	"language/expressions/call/11.2.3-3_6": {
+		"category": "tbd"
+	},
+	"language/expressions/call/11.2.3-3_7": {
+		"category": "not_es3"
+	},
+	"language/expressions/call/S11.2.3_A1": {
+		"category": ""
+	},
+	"language/expressions/class/name": {
+		"category": "not_es3"
+	},
+	"language/expressions/class/restricted-properties": {
+		"category": "not_es3"
+	},
+	"language/expressions/comma/S11.14_A1": {
+		"category": ""
+	},
+	"language/expressions/compound-assignment/S11.13.2_A1_T1": {
+		"category": ""
+	},
+	"language/expressions/compound-assignment/S11.13.2_A1_T10": {
+		"category": ""
+	},
+	"language/expressions/compound-assignment/S11.13.2_A1_T11": {
+		"category": ""
+	},
+	"language/expressions/compound-assignment/S11.13.2_A1_T2": {
+		"category": ""
+	},
+	"language/expressions/compound-assignment/S11.13.2_A1_T3": {
+		"category": ""
+	},
+	"language/expressions/compound-assignment/S11.13.2_A1_T4": {
+		"category": ""
+	},
+	"language/expressions/compound-assignment/S11.13.2_A1_T5": {
+		"category": ""
+	},
+	"language/expressions/compound-assignment/S11.13.2_A1_T6": {
+		"category": ""
+	},
+	"language/expressions/compound-assignment/S11.13.2_A1_T7": {
+		"category": ""
+	},
+	"language/expressions/compound-assignment/S11.13.2_A1_T8": {
+		"category": ""
+	},
+	"language/expressions/compound-assignment/S11.13.2_A1_T9": {
+		"category": ""
+	},
+	"language/expressions/compound-assignment/S11.13.2_A5.10_T1": {
+		"category": "not_es3"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A5.10_T2": {
+		"category": "not_es3"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A5.10_T3": {
+		"category": "not_es3"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A5.10_T4": {
+		"category": "not_es3"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A5.10_T5": {
+		"category": "not_es3"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A5.11_T1": {
+		"category": "not_es3"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A5.11_T2": {
+		"category": "not_es3"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A5.11_T3": {
+		"category": "not_es3"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A5.11_T4": {
+		"category": "not_es3"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A5.11_T5": {
+		"category": "not_es3"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A5.1_T1": {
+		"category": "not_es3"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A5.1_T2": {
+		"category": "not_es3"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A5.1_T3": {
+		"category": "not_es3"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A5.1_T4": {
+		"category": "not_es3"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A5.1_T5": {
+		"category": "not_es3"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A5.2_T1": {
+		"category": "not_es3"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A5.2_T2": {
+		"category": "not_es3"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A5.2_T3": {
+		"category": "not_es3"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A5.2_T4": {
+		"category": "not_es3"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A5.2_T5": {
+		"category": "not_es3"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A5.3_T1": {
+		"category": "not_es3"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A5.3_T2": {
+		"category": "not_es3"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A5.3_T3": {
+		"category": "not_es3"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A5.3_T4": {
+		"category": "not_es3"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A5.3_T5": {
+		"category": "not_es3"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A5.4_T1": {
+		"category": "not_es3"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A5.4_T2": {
+		"category": "not_es3"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A5.4_T3": {
+		"category": "not_es3"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A5.4_T4": {
+		"category": "not_es3"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A5.4_T5": {
+		"category": "not_es3"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A5.5_T1": {
+		"category": "not_es3"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A5.5_T2": {
+		"category": "not_es3"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A5.5_T3": {
+		"category": "not_es3"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A5.5_T4": {
+		"category": "not_es3"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A5.5_T5": {
+		"category": "not_es3"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A5.6_T1": {
+		"category": "not_es3"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A5.6_T2": {
+		"category": "not_es3"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A5.6_T3": {
+		"category": "not_es3"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A5.6_T4": {
+		"category": "not_es3"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A5.6_T5": {
+		"category": "not_es3"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A5.7_T1": {
+		"category": "not_es3"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A5.7_T2": {
+		"category": "not_es3"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A5.7_T3": {
+		"category": "not_es3"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A5.7_T4": {
+		"category": "not_es3"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A5.7_T5": {
+		"category": "not_es3"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A5.8_T1": {
+		"category": "not_es3"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A5.8_T2": {
+		"category": "not_es3"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A5.8_T3": {
+		"category": "not_es3"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A5.8_T4": {
+		"category": "not_es3"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A5.8_T5": {
+		"category": "not_es3"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A5.9_T1": {
+		"category": "not_es3"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A5.9_T2": {
+		"category": "not_es3"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A5.9_T3": {
+		"category": "not_es3"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A5.9_T4": {
+		"category": "not_es3"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A5.9_T5": {
+		"category": "not_es3"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A6.10_T1": {
+		"category": "tbd"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A6.11_T1": {
+		"category": "tbd"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A6.1_T1": {
+		"category": "tbd"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A6.2_T1": {
+		"category": "tbd"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A6.3_T1": {
+		"category": "tbd"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A6.4_T1": {
+		"category": "tbd"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A6.5_T1": {
+		"category": "tbd"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A6.6_T1": {
+		"category": "tbd"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A6.7_T1": {
+		"category": "tbd"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A6.8_T1": {
+		"category": "tbd"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A6.9_T1": {
+		"category": "tbd"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A7.10_T1": {
+		"category": "tbd"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A7.10_T2": {
+		"category": "tbd"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A7.11_T1": {
+		"category": "tbd"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A7.11_T2": {
+		"category": "tbd"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A7.1_T1": {
+		"category": "tbd"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A7.1_T2": {
+		"category": "tbd"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A7.2_T1": {
+		"category": "tbd"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A7.2_T2": {
+		"category": "tbd"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A7.3_T1": {
+		"category": "tbd"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A7.3_T2": {
+		"category": "tbd"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A7.4_T1": {
+		"category": "tbd"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A7.4_T2": {
+		"category": "tbd"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A7.5_T1": {
+		"category": "tbd"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A7.5_T2": {
+		"category": "tbd"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A7.6_T1": {
+		"category": "tbd"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A7.6_T2": {
+		"category": "tbd"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A7.7_T1": {
+		"category": "tbd"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A7.7_T2": {
+		"category": "tbd"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A7.8_T1": {
+		"category": "tbd"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A7.8_T2": {
+		"category": "tbd"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A7.9_T1": {
+		"category": "tbd"
+	},
+	"language/expressions/compound-assignment/S11.13.2_A7.9_T2": {
+		"category": "tbd"
+	},
+	"language/expressions/conditional/S11.12_A1": {
+		"category": ""
+	},
+	"language/expressions/conditional/symbol-conditional-evaluation": {
+		"category": "not_es3"
+	},
+	"language/expressions/delete/S11.4.1_A1": {
+		"category": ""
+	},
+	"language/expressions/division/S11.5.2_A1": {
+		"category": ""
+	},
+	"language/expressions/does-not-equals/S11.9.2_A1": {
+		"category": ""
+	},
+	"language/expressions/does-not-equals/S11.9.2_A3.2": {
+		"category": ""
+	},
+	"language/expressions/does-not-equals/S11.9.2_A3.3": {
+		"category": ""
+	},
+	"language/expressions/does-not-equals/S11.9.2_A7.2": {
+		"category": ""
+	},
+	"language/expressions/does-not-equals/S11.9.2_A7.3": {
+		"category": ""
+	},
+	"language/expressions/does-not-equals/S11.9.2_A7.8": {
+		"category": ""
+	},
+	"language/expressions/does-not-equals/S11.9.2_A7.9": {
+		"category": ""
+	},
+	"language/expressions/equals/S11.9.1_A1": {
+		"category": ""
+	},
+	"language/expressions/equals/S11.9.1_A7.2": {
+		"category": ""
+	},
+	"language/expressions/equals/S11.9.1_A7.3": {
+		"category": ""
+	},
+	"language/expressions/equals/S11.9.1_A7.8": {
+		"category": ""
+	},
+	"language/expressions/equals/S11.9.1_A7.9": {
+		"category": ""
+	},
+	"language/expressions/equals/coerce-symbol-to-prim-err": {
+		"category": "not_es3"
+	},
+	"language/expressions/equals/coerce-symbol-to-prim-invocation": {
+		"category": "not_es3"
+	},
+	"language/expressions/equals/coerce-symbol-to-prim-return-obj": {
+		"category": "not_es3"
+	},
+	"language/expressions/equals/coerce-symbol-to-prim-return-prim": {
+		"category": "not_es3"
+	},
+	"language/expressions/equals/get-symbol-to-prim-err": {
+		"category": "tbd"
+	},
+	"language/expressions/equals/symbol-abstract-equality-comparison": {
+		"category": "not_es3"
+	},
+	"language/expressions/equals/symbol-strict-equality-comparison": {
+		"category": "not_es3"
+	},
+	"language/expressions/exponentiation/applying-the-exp-operator_A1": {
+		"category": "not_es3"
+	},
+	"language/expressions/exponentiation/applying-the-exp-operator_A10": {
+		"category": ""
+	},
+	"language/expressions/exponentiation/applying-the-exp-operator_A11": {
+		"category": "not_es3"
+	},
+	"language/expressions/exponentiation/applying-the-exp-operator_A12": {
+		"category": "not_es3"
+	},
+	"language/expressions/exponentiation/applying-the-exp-operator_A13": {
+		"category": "not_es3"
+	},
+	"language/expressions/exponentiation/applying-the-exp-operator_A14": {
+		"category": "not_es3"
+	},
+	"language/expressions/exponentiation/applying-the-exp-operator_A15": {
+		"category": "not_es3"
+	},
+	"language/expressions/exponentiation/applying-the-exp-operator_A16": {
+		"category": "not_es3"
+	},
+	"language/expressions/exponentiation/applying-the-exp-operator_A17": {
+		"category": "not_es3"
+	},
+	"language/expressions/exponentiation/applying-the-exp-operator_A18": {
+		"category": "not_es3"
+	},
+	"language/expressions/exponentiation/applying-the-exp-operator_A19": {
+		"category": "not_es3"
+	},
+	"language/expressions/exponentiation/applying-the-exp-operator_A2": {
+		"category": "not_es3"
+	},
+	"language/expressions/exponentiation/applying-the-exp-operator_A20": {
+		"category": "not_es3"
+	},
+	"language/expressions/exponentiation/applying-the-exp-operator_A21": {
+		"category": "not_es3"
+	},
+	"language/expressions/exponentiation/applying-the-exp-operator_A22": {
+		"category": "not_es3"
+	},
+	"language/expressions/exponentiation/applying-the-exp-operator_A23": {
+		"category": "not_es3"
+	},
+	"language/expressions/exponentiation/applying-the-exp-operator_A24": {
+		"category": "not_es3"
+	},
+	"language/expressions/exponentiation/applying-the-exp-operator_A3": {
+		"category": "not_es3"
+	},
+	"language/expressions/exponentiation/applying-the-exp-operator_A4": {
+		"category": "not_es3"
+	},
+	"language/expressions/exponentiation/applying-the-exp-operator_A5": {
+		"category": "not_es3"
+	},
+	"language/expressions/exponentiation/applying-the-exp-operator_A6": {
+		"category": "not_es3"
+	},
+	"language/expressions/exponentiation/applying-the-exp-operator_A7": {
+		"category": "not_es3"
+	},
+	"language/expressions/exponentiation/applying-the-exp-operator_A8": {
+		"category": "not_es3"
+	},
+	"language/expressions/exponentiation/applying-the-exp-operator_A9": {
+		"category": "not_es3"
+	},
+	"language/expressions/exponentiation/exp-assignment-operator": {
+		"category": "not_es3"
+	},
+	"language/expressions/exponentiation/exp-operator": {
+		"category": "not_es3"
+	},
+	"language/expressions/exponentiation/exp-operator-evaluation-order": {
+		"category": "not_es3"
+	},
+	"language/expressions/exponentiation/exp-operator-precedence-unary-expression-semantics": {
+		"category": "not_es3"
+	},
+	"language/expressions/exponentiation/exp-operator-precedence-update-expression-semantics": {
+		"category": "not_es3"
+	},
+	"language/expressions/function/name": {
+		"category": "not_es3"
+	},
+	"language/expressions/generators/has-instance": {
+		"category": "not_es3"
+	},
+	"language/expressions/generators/implicit-name": {
+		"category": "not_es3"
+	},
+	"language/expressions/generators/invoke-as-constructor": {
+		"category": "not_es3"
+	},
+	"language/expressions/generators/length-property-descriptor": {
+		"category": "not_es3"
+	},
+	"language/expressions/generators/name": {
+		"category": "not_es3"
+	},
+	"language/expressions/generators/no-name": {
+		"category": "not_es3"
+	},
+	"language/expressions/generators/no-yield": {
+		"category": "not_es3"
+	},
+	"language/expressions/generators/prototype-own-properties": {
+		"category": "not_es3"
+	},
+	"language/expressions/generators/prototype-property-descriptor": {
+		"category": "not_es3"
+	},
+	"language/expressions/generators/prototype-relation-to-function": {
+		"category": "not_es3"
+	},
+	"language/expressions/generators/prototype-typeof": {
+		"category": "not_es3"
+	},
+	"language/expressions/generators/prototype-uniqueness": {
+		"category": "not_es3"
+	},
+	"language/expressions/generators/prototype-value": {
+		"category": "not_es3"
+	},
+	"language/expressions/generators/return": {
+		"category": "not_es3"
+	},
+	"language/expressions/generators/yield-as-expression-with-rhs": {
+		"category": "not_es3"
+	},
+	"language/expressions/generators/yield-as-expression-without-rhs": {
+		"category": "not_es3"
+	},
+	"language/expressions/generators/yield-as-function-expression-binding-identifier": {
+		"category": "not_es3"
+	},
+	"language/expressions/generators/yield-as-identifier-in-nested-function": {
+		"category": "not_es3"
+	},
+	"language/expressions/generators/yield-as-literal-property-name": {
+		"category": "not_es3"
+	},
+	"language/expressions/generators/yield-as-property-name": {
+		"category": "not_es3"
+	},
+	"language/expressions/generators/yield-as-statement": {
+		"category": "not_es3"
+	},
+	"language/expressions/generators/yield-as-yield-operand": {
+		"category": "not_es3"
+	},
+	"language/expressions/generators/yield-newline": {
+		"category": "not_es3"
+	},
+	"language/expressions/generators/yield-star-before-newline": {
+		"category": "not_es3"
+	},
+	"language/expressions/greater-than-or-equal/S11.8.4_A1": {
+		"category": ""
+	},
+	"language/expressions/greater-than/S11.8.2_A1": {
+		"category": ""
+	},
+	"language/expressions/grouping/S11.1.6_A1": {
+		"category": ""
+	},
+	"language/expressions/in/S11.8.7_A1": {
+		"category": ""
+	},
+	"language/expressions/in/S8.12.6_A2_T2": {
+		"category": ""
+	},
+	"language/expressions/instanceof/S11.8.6_A1": {
+		"category": ""
+	},
+	"language/expressions/instanceof/prototype-getter-with-object": {
+		"category": "not_es3"
+	},
+	"language/expressions/instanceof/prototype-getter-with-object-throws": {
+		"category": "not_es3"
+	},
+	"language/expressions/instanceof/symbol-hasinstance-get-err": {
+		"category": "not_es3"
+	},
+	"language/expressions/instanceof/symbol-hasinstance-invocation": {
+		"category": "not_es3"
+	},
+	"language/expressions/instanceof/symbol-hasinstance-not-callable": {
+		"category": "not_es3"
+	},
+	"language/expressions/instanceof/symbol-hasinstance-to-boolean": {
+		"category": "not_es3"
+	},
+	"language/expressions/left-shift/S11.7.1_A1": {
+		"category": ""
+	},
+	"language/expressions/less-than-or-equal/S11.8.3_A1": {
+		"category": ""
+	},
+	"language/expressions/less-than/S11.8.1_A1": {
+		"category": ""
+	},
+	"language/expressions/logical-and/S11.11.1_A1": {
+		"category": ""
+	},
+	"language/expressions/logical-and/symbol-logical-and-evaluation": {
+		"category": "not_es3"
+	},
+	"language/expressions/logical-not/S11.4.9_A1": {
+		"category": ""
+	},
+	"language/expressions/logical-not/symbol-logical-not-evaluation": {
+		"category": "not_es3"
+	},
+	"language/expressions/logical-or/S11.11.2_A1": {
+		"category": ""
+	},
+	"language/expressions/logical-or/symbol-logical-or-evaluation": {
+		"category": "not_es3"
+	},
+	"language/expressions/modulus/S11.5.3_A1": {
+		"category": ""
+	},
+	"language/expressions/multiplication/S11.5.1_A1": {
+		"category": ""
+	},
+	"language/expressions/new/S11.2.2_A1.1": {
+		"category": ""
+	},
+	"language/expressions/new/S11.2.2_A1.2": {
+		"category": ""
 	},
 	"language/expressions/object/11.1.5-3-s": {
 		"category": "not_es3"
@@ -7895,1273 +22592,2887 @@
 	"language/expressions/object/11.1.5-4-s": {
 		"category": "not_es3"
 	},
-	"language/expressions/assignment/destructuring/obj-prop-nested-obj-invalid": {
+	"language/expressions/object/11.1.5_5-4-1": {
+		"category": "tbd"
+	},
+	"language/expressions/object/11.1.5_6-2-2-s": {
 		"category": "not_es3"
 	},
-	"language/expressions/assignment/destructuring/array-elem-nested-obj-invalid": {
+	"language/expressions/object/11.1.5_6-3-1": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/11.1.5_6-3-2": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/11.1.5_7-3-1": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/11.1.5_7-3-2": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/concise-generator": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/descriptor": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/fn-name-accessor-get": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/fn-name-accessor-set": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/fn-name-arrow": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/fn-name-class": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/fn-name-cover": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/fn-name-fn": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/fn-name-gen": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/getter": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/identifier-reference-property-get-access": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/let-non-strict-access": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/let-non-strict-syntax": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/method": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/method-definition/fn-name-fn": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/method-definition/fn-name-gen": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/method-definition/generator-invoke-ctor": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/method-definition/generator-invoke-fn-no-strict": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/method-definition/generator-invoke-fn-strict": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/method-definition/generator-length": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/method-definition/generator-name-prop-string": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/method-definition/generator-name-prop-symbol": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/method-definition/generator-no-yield": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/method-definition/generator-params": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/method-definition/generator-prop-name-eval-error": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/method-definition/generator-prop-name-yield-expr": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/method-definition/generator-prop-name-yield-id": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/method-definition/generator-property-desc": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/method-definition/generator-prototype": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/method-definition/generator-prototype-prop": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/method-definition/generator-return": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/method-definition/generator-super-prop-body": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/method-definition/generator-super-prop-param": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/method-definition/name-invoke-ctor": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/method-definition/name-invoke-fn-no-strict": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/method-definition/name-invoke-fn-strict": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/method-definition/name-length": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/method-definition/name-name-prop-string": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/method-definition/name-name-prop-symbol": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/method-definition/name-param-id-yield": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/method-definition/name-param-init-yield": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/method-definition/name-params": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/method-definition/name-prop-name-eval-error": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/method-definition/name-prop-name-yield-expr": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/method-definition/name-prop-name-yield-id": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/method-definition/name-property-desc": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/method-definition/name-prototype": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/method-definition/name-prototype-prop": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/method-definition/name-super-prop-body": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/method-definition/name-super-prop-param": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/method-definition/yield-as-expression-with-rhs": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/method-definition/yield-as-expression-without-rhs": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/method-definition/yield-as-function-expression-binding-identifier": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/method-definition/yield-as-generator-method-binding-identifier": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/method-definition/yield-as-identifier-in-nested-function": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/method-definition/yield-as-literal-property-name": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/method-definition/yield-as-property-name": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/method-definition/yield-as-statement": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/method-definition/yield-as-yield-operand": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/method-definition/yield-newline": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/method-definition/yield-return": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/method-definition/yield-star-before-newline": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/not-defined": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/prop-def-id-eval-error": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/prop-def-id-eval-error-2": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/prop-def-id-get-error": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/prop-def-id-valid": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/properties-names-eval-arguments": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/setter": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/yield-non-strict-access": {
+		"category": "not_es3"
+	},
+	"language/expressions/object/yield-non-strict-syntax": {
+		"category": "not_es3"
+	},
+	"language/expressions/postfix-decrement/S11.3.2_A1.2_T1": {
+		"category": ""
+	},
+	"language/expressions/postfix-decrement/S11.3.2_A5_T1": {
+		"category": "not_es3"
+	},
+	"language/expressions/postfix-decrement/S11.3.2_A5_T2": {
+		"category": "not_es3"
+	},
+	"language/expressions/postfix-decrement/S11.3.2_A5_T3": {
+		"category": "not_es3"
+	},
+	"language/expressions/postfix-decrement/S11.3.2_A5_T4": {
+		"category": "not_es3"
+	},
+	"language/expressions/postfix-decrement/S11.3.2_A5_T5": {
+		"category": "not_es3"
+	},
+	"language/expressions/postfix-decrement/S11.3.2_A6_T1": {
+		"category": "by_design"
+	},
+	"language/expressions/postfix-decrement/S11.3.2_A6_T2": {
+		"category": "by_design"
+	},
+	"language/expressions/postfix-increment/S11.3.1_A1.2_T1": {
+		"category": ""
+	},
+	"language/expressions/postfix-increment/S11.3.1_A5_T1": {
+		"category": "not_es3"
+	},
+	"language/expressions/postfix-increment/S11.3.1_A5_T2": {
+		"category": "not_es3"
+	},
+	"language/expressions/postfix-increment/S11.3.1_A5_T3": {
+		"category": "not_es3"
+	},
+	"language/expressions/postfix-increment/S11.3.1_A5_T4": {
+		"category": "not_es3"
+	},
+	"language/expressions/postfix-increment/S11.3.1_A5_T5": {
+		"category": "not_es3"
+	},
+	"language/expressions/postfix-increment/S11.3.1_A6_T1": {
+		"category": "by_design"
+	},
+	"language/expressions/postfix-increment/S11.3.1_A6_T2": {
+		"category": "by_design"
+	},
+	"language/expressions/prefix-decrement/S11.4.5_A1": {
+		"category": ""
+	},
+	"language/expressions/prefix-decrement/S11.4.5_A5_T1": {
+		"category": "not_es3"
+	},
+	"language/expressions/prefix-decrement/S11.4.5_A5_T2": {
+		"category": "not_es3"
+	},
+	"language/expressions/prefix-decrement/S11.4.5_A5_T3": {
+		"category": "not_es3"
+	},
+	"language/expressions/prefix-decrement/S11.4.5_A5_T4": {
+		"category": "not_es3"
+	},
+	"language/expressions/prefix-decrement/S11.4.5_A5_T5": {
+		"category": "not_es3"
+	},
+	"language/expressions/prefix-decrement/S11.4.5_A6_T1": {
+		"category": "by_design"
+	},
+	"language/expressions/prefix-decrement/S11.4.5_A6_T2": {
+		"category": "by_design"
+	},
+	"language/expressions/prefix-increment/S11.4.4_A1": {
+		"category": ""
+	},
+	"language/expressions/prefix-increment/S11.4.4_A5_T1": {
+		"category": "not_es3"
+	},
+	"language/expressions/prefix-increment/S11.4.4_A5_T2": {
+		"category": "not_es3"
+	},
+	"language/expressions/prefix-increment/S11.4.4_A5_T3": {
+		"category": "not_es3"
+	},
+	"language/expressions/prefix-increment/S11.4.4_A5_T4": {
+		"category": "not_es3"
+	},
+	"language/expressions/prefix-increment/S11.4.4_A5_T5": {
+		"category": "not_es3"
+	},
+	"language/expressions/prefix-increment/S11.4.4_A6_T1": {
+		"category": "by_design"
+	},
+	"language/expressions/prefix-increment/S11.4.4_A6_T2": {
+		"category": "by_design"
+	},
+	"language/expressions/property-accessors/S11.2.1_A1.1": {
+		"category": ""
+	},
+	"language/expressions/property-accessors/S11.2.1_A1.2": {
+		"category": ""
+	},
+	"language/expressions/right-shift/S11.7.2_A1": {
+		"category": ""
+	},
+	"language/expressions/strict-does-not-equals/S11.9.5_A1": {
+		"category": ""
+	},
+	"language/expressions/strict-equals/S11.9.4_A1": {
+		"category": ""
+	},
+	"language/expressions/subtraction/S11.6.2_A1": {
+		"category": ""
+	},
+	"language/expressions/tagged-template/cache-differing-expressions": {
+		"category": "not_es3"
+	},
+	"language/expressions/tagged-template/cache-differing-expressions-eval": {
+		"category": "not_es3"
+	},
+	"language/expressions/tagged-template/cache-differing-expressions-new-function": {
+		"category": "not_es3"
+	},
+	"language/expressions/tagged-template/cache-differing-raw-strings": {
+		"category": "not_es3"
+	},
+	"language/expressions/tagged-template/cache-differing-string-count": {
+		"category": "not_es3"
+	},
+	"language/expressions/tagged-template/cache-identical-source": {
+		"category": "not_es3"
+	},
+	"language/expressions/tagged-template/cache-identical-source-eval": {
+		"category": "not_es3"
+	},
+	"language/expressions/tagged-template/cache-identical-source-new-function": {
+		"category": "not_es3"
+	},
+	"language/expressions/tagged-template/call-expression-argument-list-evaluation": {
+		"category": "not_es3"
+	},
+	"language/expressions/tagged-template/call-expression-context-no-strict": {
+		"category": "not_es3"
+	},
+	"language/expressions/tagged-template/chained-application": {
+		"category": "not_es3"
+	},
+	"language/expressions/tagged-template/constructor-invocation": {
+		"category": "not_es3"
+	},
+	"language/expressions/tagged-template/member-expression-argument-list-evaluation": {
+		"category": "not_es3"
+	},
+	"language/expressions/tagged-template/member-expression-context": {
+		"category": "not_es3"
+	},
+	"language/expressions/tagged-template/template-object": {
+		"category": "not_es3"
+	},
+	"language/expressions/tagged-template/template-object-frozen-non-strict": {
+		"category": "not_es3"
+	},
+	"language/expressions/template-literal/evaluation-order": {
+		"category": "not_es3"
+	},
+	"language/expressions/template-literal/literal-expr-abrupt": {
+		"category": "not_es3"
+	},
+	"language/expressions/template-literal/literal-expr-function": {
+		"category": "not_es3"
+	},
+	"language/expressions/template-literal/literal-expr-member-expr": {
+		"category": "not_es3"
+	},
+	"language/expressions/template-literal/literal-expr-method": {
+		"category": "not_es3"
+	},
+	"language/expressions/template-literal/literal-expr-obj": {
+		"category": "not_es3"
+	},
+	"language/expressions/template-literal/literal-expr-primitive": {
+		"category": "not_es3"
+	},
+	"language/expressions/template-literal/literal-expr-template": {
+		"category": "not_es3"
+	},
+	"language/expressions/template-literal/literal-expr-tostr-error": {
+		"category": "not_es3"
+	},
+	"language/expressions/template-literal/middle-list-many-expr-abrupt": {
+		"category": "not_es3"
+	},
+	"language/expressions/template-literal/middle-list-many-expr-function": {
+		"category": "not_es3"
+	},
+	"language/expressions/template-literal/middle-list-many-expr-member-expr": {
+		"category": "not_es3"
+	},
+	"language/expressions/template-literal/middle-list-many-expr-method": {
+		"category": "not_es3"
+	},
+	"language/expressions/template-literal/middle-list-many-expr-obj": {
+		"category": "not_es3"
+	},
+	"language/expressions/template-literal/middle-list-many-expr-primitive": {
+		"category": "not_es3"
+	},
+	"language/expressions/template-literal/middle-list-many-expr-template": {
+		"category": "not_es3"
+	},
+	"language/expressions/template-literal/middle-list-many-expr-tostr-error": {
+		"category": "not_es3"
+	},
+	"language/expressions/template-literal/middle-list-one-expr-abrupt": {
+		"category": "not_es3"
+	},
+	"language/expressions/template-literal/middle-list-one-expr-function": {
+		"category": "not_es3"
+	},
+	"language/expressions/template-literal/middle-list-one-expr-member-expr": {
+		"category": "not_es3"
+	},
+	"language/expressions/template-literal/middle-list-one-expr-method": {
+		"category": "not_es3"
+	},
+	"language/expressions/template-literal/middle-list-one-expr-obj": {
+		"category": "not_es3"
+	},
+	"language/expressions/template-literal/middle-list-one-expr-primitive": {
+		"category": "not_es3"
+	},
+	"language/expressions/template-literal/middle-list-one-expr-template": {
+		"category": "not_es3"
+	},
+	"language/expressions/template-literal/middle-list-one-expr-tostr-error": {
+		"category": "not_es3"
+	},
+	"language/expressions/template-literal/no-sub": {
+		"category": "not_es3"
+	},
+	"language/expressions/template-literal/tv-character-escape-sequence": {
+		"category": "not_es3"
+	},
+	"language/expressions/template-literal/tv-hex-escape-sequence": {
+		"category": "not_es3"
+	},
+	"language/expressions/template-literal/tv-line-continuation": {
+		"category": "not_es3"
+	},
+	"language/expressions/template-literal/tv-line-terminator-sequence": {
+		"category": "not_es3"
+	},
+	"language/expressions/template-literal/tv-no-substitution": {
+		"category": "not_es3"
+	},
+	"language/expressions/template-literal/tv-null-character-escape-sequence": {
+		"category": "not_es3"
+	},
+	"language/expressions/template-literal/tv-template-character": {
+		"category": "not_es3"
+	},
+	"language/expressions/template-literal/tv-template-characters": {
+		"category": "not_es3"
+	},
+	"language/expressions/template-literal/tv-template-head": {
+		"category": "not_es3"
+	},
+	"language/expressions/template-literal/tv-template-middle": {
+		"category": "not_es3"
+	},
+	"language/expressions/template-literal/tv-template-tail": {
+		"category": "not_es3"
+	},
+	"language/expressions/template-literal/tv-utf16-escape-sequence": {
+		"category": "not_es3"
+	},
+	"language/expressions/template-literal/tv-zwnbsp": {
+		"category": "not_es3"
+	},
+	"language/expressions/typeof/symbol": {
+		"category": "not_es3"
+	},
+	"language/expressions/typeof/syntax": {
+		"category": ""
+	},
+	"language/expressions/unary-minus/S11.4.7_A1": {
+		"category": ""
+	},
+	"language/expressions/unary-plus/S11.4.6_A1": {
+		"category": ""
+	},
+	"language/expressions/unsigned-right-shift/S11.7.3_A1": {
+		"category": ""
+	},
+	"language/expressions/void/S11.4.2_A1": {
+		"category": ""
+	},
+	"language/expressions/yield/arguments-object-attributes": {
+		"category": "not_es3"
+	},
+	"language/expressions/yield/captured-free-vars": {
+		"category": "not_es3"
+	},
+	"language/expressions/yield/expr-value-specified": {
+		"category": "not_es3"
+	},
+	"language/expressions/yield/expr-value-unspecified": {
+		"category": "not_es3"
+	},
+	"language/expressions/yield/formal-parameters": {
+		"category": "not_es3"
+	},
+	"language/expressions/yield/formal-parameters-after-reassignment-non-strict": {
+		"category": "not_es3"
+	},
+	"language/expressions/yield/from-catch": {
+		"category": "not_es3"
+	},
+	"language/expressions/yield/from-try": {
+		"category": "not_es3"
+	},
+	"language/expressions/yield/from-with": {
+		"category": "not_es3"
+	},
+	"language/expressions/yield/star-array": {
+		"category": "not_es3"
+	},
+	"language/expressions/yield/star-iterable": {
+		"category": "not_es3"
+	},
+	"language/expressions/yield/star-string": {
+		"category": "not_es3"
+	},
+	"language/expressions/yield/then-return": {
+		"category": "not_es3"
+	},
+	"language/expressions/yield/within-for": {
+		"category": "not_es3"
+	},
+	"language/expressions/yield/yield-expr": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-1-s": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-10-s": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-100-s": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-100gs": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-102-s": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-102gs": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-103": {
+		"category": "tbd"
+	},
+	"language/function-code/10.4.3-1-105": {
+		"category": "tbd"
+	},
+	"language/function-code/10.4.3-1-10gs": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-12-s": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-12gs": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-14-s": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-14gs": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-16-s": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-16gs": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-2-s": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-3-s": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-36-s": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-36gs": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-37-s": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-37gs": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-38-s": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-38gs": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-39-s": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-39gs": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-4-s": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-40-s": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-40gs": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-41-s": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-41gs": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-42-s": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-42gs": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-43-s": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-43gs": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-44-s": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-44gs": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-45-s": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-45gs": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-46-s": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-46gs": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-47-s": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-47gs": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-48-s": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-48gs": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-49-s": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-49gs": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-50-s": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-50gs": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-51-s": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-51gs": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-52-s": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-52gs": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-53-s": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-53gs": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-58-s": {
+		"category": "tbd"
+	},
+	"language/function-code/10.4.3-1-58gs": {
+		"category": "tbd"
+	},
+	"language/function-code/10.4.3-1-59-s": {
+		"category": "tbd"
+	},
+	"language/function-code/10.4.3-1-59gs": {
+		"category": "tbd"
+	},
+	"language/function-code/10.4.3-1-60-s": {
+		"category": "tbd"
+	},
+	"language/function-code/10.4.3-1-60gs": {
+		"category": "tbd"
+	},
+	"language/function-code/10.4.3-1-61-s": {
+		"category": "tbd"
+	},
+	"language/function-code/10.4.3-1-61gs": {
+		"category": "tbd"
+	},
+	"language/function-code/10.4.3-1-62-s": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-62gs": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-63-s": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-63gs": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-64-s": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-64gs": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-65-s": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-65gs": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-66-s": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-66gs": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-67-s": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-67gs": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-68-s": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-68gs": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-71-s": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-71gs": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-72-s": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-72gs": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-73-s": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-73gs": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-76-s": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-76gs": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-77-s": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-77gs": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-78-s": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-78gs": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-79-s": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-79gs": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-8-s": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-80-s": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-80gs": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-8gs": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-95-s": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-95gs": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-96-s": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-96gs": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-97-s": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-97gs": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-98-s": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-98gs": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-99-s": {
+		"category": "not_es3"
+	},
+	"language/function-code/10.4.3-1-99gs": {
+		"category": "not_es3"
+	},
+	"language/function-code/eval-param-env-with-computed-key": {
+		"category": "not_es3"
+	},
+	"language/function-code/eval-param-env-with-prop-initializer": {
+		"category": "not_es3"
+	},
+	"language/identifier-resolution/unscopables": {
+		"category": "not_es3"
+	},
+	"language/identifiers/part-digits-via-escape-hex": {
+		"category": "tbd"
+	},
+	"language/identifiers/val-dollar-sign-via-escape-hex": {
+		"category": "tbd"
+	},
+	"language/identifiers/val-underscore-via-escape-hex": {
+		"category": "tbd"
+	},
+	"language/identifiers/vals-eng-alpha-lower-via-escape-hex": {
+		"category": "tbd"
+	},
+	"language/identifiers/vals-eng-alpha-upper-via-escape-hex": {
+		"category": "tbd"
+	},
+	"language/identifiers/vals-rus-alpha-lower-via-escape-hex": {
+		"category": "tbd"
+	},
+	"language/identifiers/vals-rus-alpha-upper-via-escape-hex": {
+		"category": "tbd"
+	},
+	"language/line-terminators/7.3-1": {
+		"category": ""
+	},
+	"language/line-terminators/7.3-2": {
+		"category": ""
+	},
+	"language/line-terminators/7.3-3": {
+		"category": ""
+	},
+	"language/line-terminators/7.3-4": {
+		"category": ""
+	},
+	"language/line-terminators/S7.3_A1.3": {
+		"category": ""
+	},
+	"language/line-terminators/S7.3_A1.4": {
+		"category": ""
+	},
+	"language/line-terminators/S7.3_A2.3": {
+		"category": ""
+	},
+	"language/line-terminators/S7.3_A2.4": {
+		"category": ""
+	},
+	"language/line-terminators/S7.3_A3.3_T2": {
+		"category": ""
+	},
+	"language/line-terminators/S7.3_A3.4_T2": {
+		"category": ""
+	},
+	"language/line-terminators/S7.3_A4_T3": {
+		"category": ""
+	},
+	"language/line-terminators/S7.3_A4_T4": {
+		"category": ""
+	},
+	"language/line-terminators/S7.3_A7_T1": {
+		"category": ""
+	},
+	"language/line-terminators/S7.3_A7_T2": {
+		"category": ""
+	},
+	"language/line-terminators/S7.3_A7_T3": {
+		"category": ""
+	},
+	"language/line-terminators/S7.3_A7_T4": {
+		"category": ""
+	},
+	"language/line-terminators/S7.3_A7_T5": {
+		"category": ""
+	},
+	"language/line-terminators/S7.3_A7_T6": {
+		"category": ""
+	},
+	"language/line-terminators/S7.3_A7_T7": {
+		"category": ""
+	},
+	"language/line-terminators/S7.3_A7_T8": {
+		"category": ""
+	},
+	"language/literals/numeric/S7.8.3_A5.1_T2": {
+		"category": ""
+	},
+	"language/literals/numeric/S7.8.3_A5.1_T4": {
+		"category": ""
+	},
+	"language/literals/numeric/S7.8.3_A5.1_T6": {
+		"category": ""
+	},
+	"language/literals/numeric/S7.8.3_A5.1_T8": {
+		"category": ""
+	},
+	"language/literals/numeric/binary": {
+		"category": "not_es3"
+	},
+	"language/literals/numeric/octal": {
+		"category": "not_es3"
+	},
+	"language/literals/regexp/7.8.5-2gs": {
+		"category": ""
+	},
+	"language/literals/regexp/S7.8.5_A1.1_T1": {
+		"category": ""
+	},
+	"language/literals/regexp/S7.8.5_A1.1_T2": {
+		"category": ""
+	},
+	"language/literals/regexp/S7.8.5_A1.4_T1": {
+		"category": ""
+	},
+	"language/literals/regexp/S7.8.5_A1.4_T2": {
+		"category": "not_es3"
+	},
+	"language/literals/regexp/S7.8.5_A2.1_T1": {
+		"category": ""
+	},
+	"language/literals/regexp/S7.8.5_A2.1_T2": {
+		"category": ""
+	},
+	"language/literals/regexp/S7.8.5_A2.4_T1": {
+		"category": ""
+	},
+	"language/literals/regexp/S7.8.5_A2.4_T2": {
+		"category": "not_es3"
+	},
+	"language/literals/regexp/S7.8.5_A3.1_T1": {
+		"category": ""
+	},
+	"language/literals/regexp/S7.8.5_A3.1_T2": {
+		"category": ""
+	},
+	"language/literals/regexp/S7.8.5_A3.1_T3": {
+		"category": ""
+	},
+	"language/literals/regexp/S7.8.5_A3.1_T4": {
+		"category": ""
+	},
+	"language/literals/regexp/S7.8.5_A3.1_T5": {
+		"category": ""
+	},
+	"language/literals/regexp/S7.8.5_A3.1_T6": {
+		"category": ""
+	},
+	"language/literals/regexp/S7.8.5_A3.1_T7": {
+		"category": ""
+	},
+	"language/literals/regexp/S7.8.5_A3.1_T8": {
+		"category": ""
+	},
+	"language/literals/regexp/S7.8.5_A3.1_T9": {
+		"category": ""
+	},
+	"language/literals/regexp/S7.8.5_A4.1": {
+		"category": ""
+	},
+	"language/literals/regexp/S7.8.5_A4.2": {
+		"category": ""
+	},
+	"language/literals/regexp/u-astral": {
+		"category": "not_es3"
+	},
+	"language/literals/regexp/u-case-mapping": {
+		"category": "not_es3"
+	},
+	"language/literals/regexp/u-surrogate-pairs": {
+		"category": "not_es3"
+	},
+	"language/literals/regexp/u-unicode-esc": {
+		"category": "not_es3"
+	},
+	"language/literals/string/7.8.4-1-s": {
+		"category": "tbd"
+	},
+	"language/module-code/strict-mode": {
+		"category": "not_es3"
+	},
+	"language/reserved-words/7.6.1-1-1": {
+		"category": ""
+	},
+	"language/reserved-words/7.6.1-1-10": {
+		"category": ""
+	},
+	"language/reserved-words/7.6.1-1-11": {
+		"category": ""
+	},
+	"language/reserved-words/7.6.1-1-12": {
+		"category": ""
+	},
+	"language/reserved-words/7.6.1-1-13": {
+		"category": ""
+	},
+	"language/reserved-words/7.6.1-1-14": {
+		"category": ""
+	},
+	"language/reserved-words/7.6.1-1-15": {
+		"category": ""
+	},
+	"language/reserved-words/7.6.1-1-16": {
+		"category": ""
+	},
+	"language/reserved-words/7.6.1-1-2": {
+		"category": ""
+	},
+	"language/reserved-words/7.6.1-1-3": {
+		"category": ""
+	},
+	"language/reserved-words/7.6.1-1-4": {
+		"category": ""
+	},
+	"language/reserved-words/7.6.1-1-5": {
+		"category": ""
+	},
+	"language/reserved-words/7.6.1-1-6": {
+		"category": ""
+	},
+	"language/reserved-words/7.6.1-1-7": {
+		"category": ""
+	},
+	"language/reserved-words/7.6.1-1-8": {
+		"category": ""
+	},
+	"language/reserved-words/7.6.1-1-9": {
+		"category": ""
+	},
+	"language/reserved-words/7.6.1-2-1": {
+		"category": ""
+	},
+	"language/reserved-words/7.6.1-2-10": {
+		"category": ""
+	},
+	"language/reserved-words/7.6.1-2-11": {
+		"category": ""
+	},
+	"language/reserved-words/7.6.1-2-12": {
+		"category": ""
+	},
+	"language/reserved-words/7.6.1-2-13": {
+		"category": ""
+	},
+	"language/reserved-words/7.6.1-2-14": {
+		"category": ""
+	},
+	"language/reserved-words/7.6.1-2-15": {
+		"category": ""
+	},
+	"language/reserved-words/7.6.1-2-16": {
+		"category": ""
+	},
+	"language/reserved-words/7.6.1-2-2": {
+		"category": ""
+	},
+	"language/reserved-words/7.6.1-2-3": {
+		"category": ""
+	},
+	"language/reserved-words/7.6.1-2-4": {
+		"category": ""
+	},
+	"language/reserved-words/7.6.1-2-5": {
+		"category": ""
+	},
+	"language/reserved-words/7.6.1-2-6": {
+		"category": ""
+	},
+	"language/reserved-words/7.6.1-2-7": {
+		"category": ""
+	},
+	"language/reserved-words/7.6.1-2-8": {
+		"category": ""
+	},
+	"language/reserved-words/7.6.1-2-9": {
+		"category": ""
+	},
+	"language/reserved-words/7.6.1-3-1": {
+		"category": ""
+	},
+	"language/reserved-words/7.6.1-3-10": {
+		"category": ""
+	},
+	"language/reserved-words/7.6.1-3-11": {
+		"category": ""
+	},
+	"language/reserved-words/7.6.1-3-12": {
+		"category": ""
+	},
+	"language/reserved-words/7.6.1-3-13": {
+		"category": ""
+	},
+	"language/reserved-words/7.6.1-3-14": {
+		"category": ""
+	},
+	"language/reserved-words/7.6.1-3-15": {
+		"category": ""
+	},
+	"language/reserved-words/7.6.1-3-16": {
+		"category": ""
+	},
+	"language/reserved-words/7.6.1-3-2": {
+		"category": ""
+	},
+	"language/reserved-words/7.6.1-3-3": {
+		"category": ""
+	},
+	"language/reserved-words/7.6.1-3-4": {
+		"category": ""
+	},
+	"language/reserved-words/7.6.1-3-5": {
+		"category": ""
+	},
+	"language/reserved-words/7.6.1-3-6": {
+		"category": ""
+	},
+	"language/reserved-words/7.6.1-3-7": {
+		"category": ""
+	},
+	"language/reserved-words/7.6.1-3-8": {
+		"category": ""
+	},
+	"language/reserved-words/7.6.1-3-9": {
+		"category": ""
+	},
+	"language/reserved-words/7.6.1-4-1": {
+		"category": "not_es3"
+	},
+	"language/reserved-words/7.6.1-4-10": {
+		"category": "not_es3"
+	},
+	"language/reserved-words/7.6.1-4-11": {
+		"category": "not_es3"
+	},
+	"language/reserved-words/7.6.1-4-12": {
+		"category": "not_es3"
+	},
+	"language/reserved-words/7.6.1-4-13": {
+		"category": "not_es3"
+	},
+	"language/reserved-words/7.6.1-4-14": {
+		"category": "not_es3"
+	},
+	"language/reserved-words/7.6.1-4-15": {
+		"category": "not_es3"
+	},
+	"language/reserved-words/7.6.1-4-16": {
+		"category": "not_es3"
+	},
+	"language/reserved-words/7.6.1-4-2": {
+		"category": "not_es3"
+	},
+	"language/reserved-words/7.6.1-4-3": {
+		"category": "not_es3"
+	},
+	"language/reserved-words/7.6.1-4-4": {
+		"category": "not_es3"
+	},
+	"language/reserved-words/7.6.1-4-5": {
+		"category": "not_es3"
+	},
+	"language/reserved-words/7.6.1-4-6": {
+		"category": "not_es3"
+	},
+	"language/reserved-words/7.6.1-4-7": {
+		"category": "not_es3"
+	},
+	"language/reserved-words/7.6.1-4-8": {
+		"category": "not_es3"
+	},
+	"language/reserved-words/7.6.1-4-9": {
+		"category": "not_es3"
+	},
+	"language/reserved-words/7.6.1-8-1": {
+		"category": "not_es3"
+	},
+	"language/reserved-words/7.6.1-8-10": {
+		"category": "not_es3"
+	},
+	"language/reserved-words/7.6.1-8-11": {
+		"category": "not_es3"
+	},
+	"language/reserved-words/7.6.1-8-12": {
+		"category": "not_es3"
+	},
+	"language/reserved-words/7.6.1-8-13": {
+		"category": "not_es3"
+	},
+	"language/reserved-words/7.6.1-8-14": {
+		"category": "not_es3"
+	},
+	"language/reserved-words/7.6.1-8-15": {
+		"category": "not_es3"
+	},
+	"language/reserved-words/7.6.1-8-16": {
+		"category": "not_es3"
+	},
+	"language/reserved-words/7.6.1-8-2": {
+		"category": "not_es3"
+	},
+	"language/reserved-words/7.6.1-8-3": {
+		"category": "not_es3"
+	},
+	"language/reserved-words/7.6.1-8-4": {
+		"category": "not_es3"
+	},
+	"language/reserved-words/7.6.1-8-5": {
+		"category": "not_es3"
+	},
+	"language/reserved-words/7.6.1-8-6": {
+		"category": "not_es3"
+	},
+	"language/reserved-words/7.6.1-8-7": {
+		"category": "not_es3"
+	},
+	"language/reserved-words/7.6.1-8-8": {
+		"category": "not_es3"
+	},
+	"language/reserved-words/7.6.1-8-9": {
+		"category": "not_es3"
+	},
+	"language/reserved-words/await-module": {
+		"category": "not_es3"
+	},
+	"language/rest-parameters/array-pattern": {
+		"category": "not_es3"
+	},
+	"language/rest-parameters/arrow-function": {
+		"category": "not_es3"
+	},
+	"language/rest-parameters/expected-argument-count": {
+		"category": "not_es3"
+	},
+	"language/rest-parameters/no-alias-arguments": {
+		"category": "not_es3"
+	},
+	"language/rest-parameters/object-pattern": {
+		"category": "not_es3"
+	},
+	"language/rest-parameters/rest-index": {
+		"category": "not_es3"
+	},
+	"language/rest-parameters/rest-parameters-apply": {
+		"category": "not_es3"
+	},
+	"language/rest-parameters/rest-parameters-call": {
+		"category": "not_es3"
+	},
+	"language/rest-parameters/rest-parameters-produce-an-array": {
+		"category": "not_es3"
+	},
+	"language/rest-parameters/with-new-target": {
+		"category": "not_es3"
+	},
+	"language/statements/class/arguments/access": {
+		"category": "not_es3"
+	},
+	"language/statements/class/arguments/default-constructor": {
+		"category": "not_es3"
+	},
+	"language/statements/class/definition/accessors": {
+		"category": "not_es3"
+	},
+	"language/statements/class/definition/basics": {
+		"category": "not_es3"
+	},
+	"language/statements/class/definition/constructable-but-no-prototype": {
+		"category": "not_es3"
+	},
+	"language/statements/class/definition/constructor": {
+		"category": "not_es3"
+	},
+	"language/statements/class/definition/constructor-property": {
+		"category": "not_es3"
+	},
+	"language/statements/class/definition/constructor-strict-by-default": {
+		"category": "not_es3"
+	},
+	"language/statements/class/definition/fn-name-accessor-get": {
+		"category": "not_es3"
+	},
+	"language/statements/class/definition/fn-name-accessor-set": {
+		"category": "not_es3"
+	},
+	"language/statements/class/definition/fn-name-gen-method": {
+		"category": "not_es3"
+	},
+	"language/statements/class/definition/fn-name-method": {
+		"category": "not_es3"
+	},
+	"language/statements/class/definition/fn-name-static-precedence": {
+		"category": "not_es3"
+	},
+	"language/statements/class/definition/getters": {
+		"category": "not_es3"
+	},
+	"language/statements/class/definition/getters-2": {
+		"category": "not_es3"
+	},
+	"language/statements/class/definition/implicit-constructor": {
+		"category": "not_es3"
+	},
+	"language/statements/class/definition/invalid-extends": {
+		"category": "not_es3"
+	},
+	"language/statements/class/definition/methods": {
+		"category": "not_es3"
+	},
+	"language/statements/class/definition/methods-gen-no-yield": {
+		"category": "not_es3"
+	},
+	"language/statements/class/definition/methods-gen-return": {
+		"category": "not_es3"
+	},
+	"language/statements/class/definition/methods-gen-yield-as-expression-with-rhs": {
+		"category": "not_es3"
+	},
+	"language/statements/class/definition/methods-gen-yield-as-expression-without-rhs": {
+		"category": "not_es3"
+	},
+	"language/statements/class/definition/methods-gen-yield-as-generator-method-binding-identifier": {
+		"category": "not_es3"
+	},
+	"language/statements/class/definition/methods-gen-yield-as-literal-property-name": {
+		"category": "not_es3"
+	},
+	"language/statements/class/definition/methods-gen-yield-as-property-name": {
+		"category": "not_es3"
+	},
+	"language/statements/class/definition/methods-gen-yield-as-statement": {
+		"category": "not_es3"
+	},
+	"language/statements/class/definition/methods-gen-yield-as-yield-operand": {
+		"category": "not_es3"
+	},
+	"language/statements/class/definition/methods-gen-yield-newline": {
+		"category": "not_es3"
+	},
+	"language/statements/class/definition/methods-gen-yield-star-before-newline": {
+		"category": "not_es3"
+	},
+	"language/statements/class/definition/methods-named-eval-arguments": {
+		"category": "not_es3"
+	},
+	"language/statements/class/definition/methods-restricted-properties": {
+		"category": "not_es3"
+	},
+	"language/statements/class/definition/numeric-property-names": {
+		"category": "not_es3"
+	},
+	"language/statements/class/definition/prototype-getter": {
+		"category": "not_es3"
+	},
+	"language/statements/class/definition/prototype-property": {
+		"category": "not_es3"
+	},
+	"language/statements/class/definition/prototype-setter": {
+		"category": "not_es3"
+	},
+	"language/statements/class/definition/prototype-wiring": {
+		"category": "not_es3"
+	},
+	"language/statements/class/definition/setters": {
+		"category": "not_es3"
+	},
+	"language/statements/class/definition/setters-2": {
+		"category": "not_es3"
+	},
+	"language/statements/class/definition/side-effects-in-extends": {
+		"category": "not_es3"
+	},
+	"language/statements/class/definition/side-effects-in-property-define": {
+		"category": "not_es3"
+	},
+	"language/statements/class/definition/this-access-restriction": {
+		"category": "not_es3"
+	},
+	"language/statements/class/definition/this-access-restriction-2": {
+		"category": "not_es3"
+	},
+	"language/statements/class/definition/this-check-ordering": {
+		"category": "not_es3"
+	},
+	"language/statements/class/name": {
+		"category": "not_es3"
+	},
+	"language/statements/class/name-binding/basic": {
+		"category": "not_es3"
+	},
+	"language/statements/class/name-binding/const": {
+		"category": "not_es3"
+	},
+	"language/statements/class/name-binding/expression": {
+		"category": "not_es3"
+	},
+	"language/statements/class/name-binding/in-extends-expression": {
+		"category": "not_es3"
+	},
+	"language/statements/class/name-binding/in-extends-expression-assigned": {
+		"category": "not_es3"
+	},
+	"language/statements/class/name-binding/in-extends-expression-grouped": {
+		"category": "not_es3"
+	},
+	"language/statements/class/restricted-properties": {
+		"category": "not_es3"
+	},
+	"language/statements/class/strict-mode/arguments-caller": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/binding": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/Array/contructor-calls-super-multiple-arguments": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/Array/contructor-calls-super-single-argument": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/Array/length": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/Array/regular-subclassing": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/Array/super-must-be-called": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/ArrayBuffer/regular-subclassing": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/ArrayBuffer/super-must-be-called": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/Boolean/regular-subclassing": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/Boolean/super-must-be-called": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/DataView/regular-subclassing": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/DataView/super-must-be-called": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/Date/regular-subclassing": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/Date/super-must-be-called": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/Error/message-property-assignment": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/Error/regular-subclassing": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/Error/super-must-be-called": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/Function/instance-length": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/Function/instance-name": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/Function/regular-subclassing": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/Function/super-must-be-called": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/GeneratorFunction/instance-length": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/GeneratorFunction/instance-name": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/GeneratorFunction/instance-prototype": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/GeneratorFunction/regular-subclassing": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/GeneratorFunction/super-must-be-called": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/Map/regular-subclassing": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/Map/super-must-be-called": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/NativeError/EvalError-message": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/NativeError/EvalError-name": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/NativeError/EvalError-super": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/NativeError/RangeError-message": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/NativeError/RangeError-name": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/NativeError/RangeError-super": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/NativeError/ReferenceError-message": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/NativeError/ReferenceError-name": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/NativeError/ReferenceError-super": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/NativeError/SyntaxError-message": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/NativeError/SyntaxError-name": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/NativeError/SyntaxError-super": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/NativeError/TypeError-message": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/NativeError/TypeError-name": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/NativeError/TypeError-super": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/NativeError/URIError-message": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/NativeError/URIError-name": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/NativeError/URIError-super": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/Number/regular-subclassing": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/Number/super-must-be-called": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/Object/constructor-return-undefined-throws": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/Object/constructor-returns-non-object": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/Object/regular-subclassing": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/Object/replacing-prototype": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/Promise/regular-subclassing": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/Promise/super-must-be-called": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/Proxy/no-prototype-throws": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/RegExp/lastIndex": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/RegExp/regular-subclassing": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/RegExp/super-must-be-called": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/Set/regular-subclassing": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/Set/super-must-be-called": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/String/length": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/String/regular-subclassing": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/String/super-must-be-called": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/Symbol/new-symbol-with-super-throws": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/Symbol/symbol-valid-as-extends-value": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/TypedArray/regular-subclassing": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/TypedArray/super-must-be-called": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/WeakMap/regular-subclassing": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/WeakMap/super-must-be-called": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/WeakSet/regular-subclassing": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtin-objects/WeakSet/super-must-be-called": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/builtins": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/class-definition-evaluation-empty-constructor-heritage-present": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/class-definition-null-proto": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/class-definition-null-proto-contains-return-override": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/class-definition-null-proto-missing-return-override": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/class-definition-superclass-generator": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/default-constructor": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/default-constructor-2": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/derived-class-return-override-with-boolean": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/derived-class-return-override-with-empty": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/derived-class-return-override-with-null": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/derived-class-return-override-with-number": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/derived-class-return-override-with-object": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/derived-class-return-override-with-string": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/derived-class-return-override-with-symbol": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/derived-class-return-override-with-this": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/derived-class-return-override-with-undefined": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/superclass-prototype-setter-constructor": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/superclass-prototype-setter-method-override": {
+		"category": "not_es3"
+	},
+	"language/statements/class/subclass/superclass-static-method-override": {
+		"category": "not_es3"
+	},
+	"language/statements/class/super/in-constructor": {
+		"category": "not_es3"
+	},
+	"language/statements/class/super/in-getter": {
+		"category": "not_es3"
+	},
+	"language/statements/class/super/in-methods": {
+		"category": "not_es3"
+	},
+	"language/statements/class/super/in-setter": {
+		"category": "not_es3"
+	},
+	"language/statements/class/super/in-static-getter": {
+		"category": "not_es3"
+	},
+	"language/statements/class/super/in-static-methods": {
+		"category": "not_es3"
+	},
+	"language/statements/class/super/in-static-setter": {
+		"category": "not_es3"
+	},
+	"language/statements/class/syntax/class-body-has-direct-super-class-heritage": {
+		"category": "not_es3"
+	},
+	"language/statements/class/syntax/class-body-method-definition-super-property": {
+		"category": "not_es3"
+	},
+	"language/statements/class/syntax/class-declaration-binding-identifier-class-element-list": {
+		"category": "not_es3"
+	},
+	"language/statements/class/syntax/class-declaration-computed-method-definition": {
+		"category": "not_es3"
+	},
+	"language/statements/class/syntax/class-declaration-computed-method-generator-definition": {
+		"category": "not_es3"
+	},
+	"language/statements/class/syntax/class-declaration-heritage-identifier-reference-class-element-list": {
+		"category": "not_es3"
+	},
+	"language/statements/class/syntax/class-expression": {
+		"category": "not_es3"
+	},
+	"language/statements/class/syntax/class-expression-binding-identifier-opt-class-element-list": {
+		"category": "not_es3"
+	},
+	"language/statements/class/syntax/class-expression-heritage-identifier-reference": {
+		"category": "not_es3"
+	},
+	"language/statements/class/syntax/class-method-propname-constructor": {
+		"category": "not_es3"
+	},
+	"language/statements/class/syntax/early-errors/class-body-constructor-empty-missing-class-heritage": {
+		"category": "not_es3"
+	},
+	"language/statements/const/block-local-closure-get-before-initialization": {
+		"category": "not_es3"
+	},
+	"language/statements/const/block-local-use-before-initialization-in-declaration-statement": {
+		"category": "not_es3"
+	},
+	"language/statements/const/block-local-use-before-initialization-in-prior-statement": {
+		"category": "not_es3"
+	},
+	"language/statements/const/fn-name-arrow": {
+		"category": "not_es3"
+	},
+	"language/statements/const/fn-name-class": {
+		"category": "not_es3"
+	},
+	"language/statements/const/fn-name-cover": {
+		"category": "not_es3"
+	},
+	"language/statements/const/fn-name-fn": {
+		"category": "not_es3"
+	},
+	"language/statements/const/fn-name-gen": {
+		"category": "not_es3"
+	},
+	"language/statements/const/function-local-closure-get-before-initialization": {
+		"category": "not_es3"
+	},
+	"language/statements/const/function-local-use-before-initialization-in-declaration-statement": {
+		"category": "not_es3"
+	},
+	"language/statements/const/function-local-use-before-initialization-in-prior-statement": {
+		"category": "not_es3"
+	},
+	"language/statements/const/global-closure-get-before-initialization": {
+		"category": "not_es3"
+	},
+	"language/statements/const/global-use-before-initialization-in-declaration-statement": {
+		"category": "not_es3"
+	},
+	"language/statements/const/global-use-before-initialization-in-prior-statement": {
+		"category": "not_es3"
+	},
+	"language/statements/const/syntax/const": {
+		"category": "not_es3"
+	},
+	"language/statements/const/syntax/const-invalid-assignment-next-expression-for": {
+		"category": "not_es3"
+	},
+	"language/statements/const/syntax/const-invalid-assignment-statement-body-for-in": {
+		"category": "not_es3"
+	},
+	"language/statements/const/syntax/const-invalid-assignment-statement-body-for-of": {
+		"category": "not_es3"
+	},
+	"language/statements/const/syntax/const-outer-inner-let-bindings": {
+		"category": "not_es3"
+	},
+	"language/statements/const/syntax/with-initializer-case-expression-statement-list": {
+		"category": "not_es3"
+	},
+	"language/statements/const/syntax/with-initializer-default-statement-list": {
+		"category": "not_es3"
+	},
+	"language/statements/continue/labeled-continue": {
+		"category": "not_es3"
+	},
+	"language/statements/continue/nested-let-bound-for-loops-inner-continue": {
+		"category": "not_es3"
+	},
+	"language/statements/continue/nested-let-bound-for-loops-labeled-continue": {
+		"category": "not_es3"
+	},
+	"language/statements/continue/nested-let-bound-for-loops-outer-continue": {
+		"category": "not_es3"
+	},
+	"language/statements/continue/no-label-continue": {
+		"category": "not_es3"
+	},
+	"language/statements/continue/shadowing-loop-variable-in-same-scope-as-continue": {
+		"category": "not_es3"
+	},
+	"language/statements/continue/simple-and-labeled": {
+		"category": "not_es3"
+	},
+	"language/statements/do-while/cptn-abrupt-empty": {
+		"category": "tbd"
+	},
+	"language/statements/do-while/cptn-normal": {
+		"category": "tbd"
+	},
+	"language/statements/do-while/labeled-fn-stmt": {
+		"category": "tbd"
+	},
+	"language/statements/for-in/12.6.4-1": {
+		"category": ""
+	},
+	"language/statements/for-in/12.6.4-2": {
+		"category": "tbd"
+	},
+	"language/statements/for-in/S12.6.4_A1": {
+		"category": "not_es3"
+	},
+	"language/statements/for-in/S12.6.4_A14_T2": {
+		"category": ""
+	},
+	"language/statements/for-in/S12.6.4_A15": {
+		"category": ""
+	},
+	"language/statements/for-in/S12.6.4_A2": {
+		"category": "not_es3"
+	},
+	"language/statements/for-in/cptn-decl-abrupt-empty": {
+		"category": "tbd"
+	},
+	"language/statements/for-in/cptn-decl-itr": {
+		"category": "tbd"
+	},
+	"language/statements/for-in/cptn-decl-skip-itr": {
+		"category": "tbd"
+	},
+	"language/statements/for-in/cptn-decl-zero-itr": {
+		"category": "tbd"
+	},
+	"language/statements/for-in/cptn-expr-abrupt-empty": {
+		"category": "tbd"
+	},
+	"language/statements/for-in/cptn-expr-itr": {
+		"category": "tbd"
+	},
+	"language/statements/for-in/cptn-expr-skip-itr": {
+		"category": "tbd"
+	},
+	"language/statements/for-in/cptn-expr-zero-itr": {
+		"category": "tbd"
+	},
+	"language/statements/for-in/head-const-bound-names-fordecl-tdz": {
+		"category": "not_es3"
+	},
+	"language/statements/for-in/head-const-fresh-binding-per-iteration": {
+		"category": "not_es3"
+	},
+	"language/statements/for-in/head-decl-expr": {
+		"category": "not_es3"
+	},
+	"language/statements/for-in/head-expr-expr": {
+		"category": ""
+	},
+	"language/statements/for-in/head-let-bound-names-dup": {
+		"category": "not_es3"
+	},
+	"language/statements/for-in/head-let-bound-names-fordecl-tdz": {
+		"category": "not_es3"
+	},
+	"language/statements/for-in/head-let-fresh-binding-per-iteration": {
+		"category": "not_es3"
+	},
+	"language/statements/for-in/head-lhs-cover": {
+		"category": ""
+	},
+	"language/statements/for-in/head-lhs-cover-non-asnmt-trgt": {
+		"category": "not_es3"
+	},
+	"language/statements/for-in/head-lhs-invalid-asnmt-ptrn-ary": {
+		"category": "not_es3"
+	},
+	"language/statements/for-in/head-lhs-invalid-asnmt-ptrn-obj": {
+		"category": ""
+	},
+	"language/statements/for-in/head-lhs-member": {
+		"category": ""
+	},
+	"language/statements/for-in/head-lhs-non-asnmt-trgt": {
+		"category": "not_es3"
+	},
+	"language/statements/for-in/head-var-bound-names-dup": {
+		"category": "not_es3"
+	},
+	"language/statements/for-in/head-var-bound-names-in-stmt": {
+		"category": ""
+	},
+	"language/statements/for-in/head-var-expr": {
+		"category": ""
+	},
+	"language/statements/for-in/labeled-fn-stmt-lhs": {
+		"category": "not_es3"
+	},
+	"language/statements/for-in/labeled-fn-stmt-var": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/Array.prototype.Symbol.iterator": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/Array.prototype.entries": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/Array.prototype.keys": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/arguments-mapped": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/arguments-mapped-aliasing": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/arguments-mapped-mutation": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/arguments-unmapped": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/arguments-unmapped-aliasing": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/arguments-unmapped-mutation": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/array": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/array-contract": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/array-contract-expand": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/array-expand": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/array-expand-contract": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/array-key-get-error": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/body-dstr-assign": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/body-dstr-assign-error": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/body-put-error": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/break": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/break-from-catch": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/break-from-finally": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/break-from-try": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/break-label": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/break-label-from-catch": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/break-label-from-finally": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/break-label-from-try": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/continue": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/continue-from-catch": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/continue-from-finally": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/continue-from-try": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/continue-label": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/continue-label-from-catch": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/continue-label-from-finally": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/continue-label-from-try": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/cptn-decl-abrupt-empty": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/cptn-decl-itr": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/cptn-decl-no-itr": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/cptn-expr-abrupt-empty": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/cptn-expr-itr": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/cptn-expr-no-itr": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/float32array": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/float32array-mutate": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/float64array": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/float64array-mutate": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/generator": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/generator-close-via-break": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/generator-close-via-return": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/generator-close-via-throw": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/generator-next-error": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/generic-iterable": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/head-const-bound-names-fordecl-tdz": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/head-const-fresh-binding-per-iteration": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/head-expr-obj-iterator-method": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/head-expr-primitive-iterator-method": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/head-expr-to-obj": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/head-let-bound-names-fordecl-tdz": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/head-let-fresh-binding-per-iteration": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/head-lhs-cover": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/head-lhs-member": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/head-var-bound-names-dup": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/head-var-bound-names-in-stmt": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/head-var-bound-names-let": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/int16array": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/int16array-mutate": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/int32array": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/int32array-mutate": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/int8array": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/int8array-mutate": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/iterator-as-proxy": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/iterator-close-get-method-error": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/iterator-close-non-object": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/iterator-close-via-break": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/iterator-close-via-return": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/iterator-close-via-throw": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/iterator-next-error": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/iterator-next-reference": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/iterator-next-result-done-attr": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/iterator-next-result-type": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/iterator-next-result-value-attr": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/iterator-next-result-value-attr-error": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/map": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/map-contract": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/map-contract-expand": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/map-expand": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/map-expand-contract": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/nested": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/return": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/return-from-catch": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/return-from-finally": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/return-from-try": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/set": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/set-contract": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/set-contract-expand": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/set-expand": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/set-expand-contract": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/string-astral": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/string-astral-truncated": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/string-bmp": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/throw": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/throw-from-catch": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/throw-from-finally": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/uint16array": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/uint16array-mutate": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/uint32array": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/uint32array-mutate": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/uint8array": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/uint8array-mutate": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/uint8clampedarray": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/uint8clampedarray-mutate": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/yield": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/yield-from-catch": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/yield-from-finally": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/yield-from-try": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/yield-star": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/yield-star-from-catch": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/yield-star-from-finally": {
+		"category": "not_es3"
+	},
+	"language/statements/for-of/yield-star-from-try": {
+		"category": "not_es3"
+	},
+	"language/statements/for/S12.6.3_A9": {
+		"category": "tbd"
+	},
+	"language/statements/for/S12.6.3_A9.1": {
+		"category": "tbd"
+	},
+	"language/statements/for/cptn-decl-expr-iter": {
+		"category": "tbd"
+	},
+	"language/statements/for/cptn-decl-expr-no-iter": {
+		"category": "tbd"
+	},
+	"language/statements/for/cptn-expr-expr-iter": {
+		"category": "tbd"
+	},
+	"language/statements/for/cptn-expr-expr-no-iter": {
+		"category": "tbd"
+	},
+	"language/statements/for/head-const-fresh-binding-per-iteration": {
+		"category": "not_es3"
+	},
+	"language/statements/for/head-let-fresh-binding-per-iteration": {
+		"category": "not_es3"
+	},
+	"language/statements/for/labeled-fn-stmt-expr": {
+		"category": "tbd"
+	},
+	"language/statements/for/labeled-fn-stmt-var": {
+		"category": "tbd"
+	},
+	"language/statements/function/13.0-10-s": {
+		"category": "not_es3"
+	},
+	"language/statements/function/13.0-11-s": {
+		"category": "not_es3"
+	},
+	"language/statements/function/13.0-13-s": {
+		"category": "not_es3"
+	},
+	"language/statements/function/13.0-14-s": {
+		"category": "not_es3"
+	},
+	"language/statements/function/13.0-15-s": {
+		"category": "not_es3"
+	},
+	"language/statements/function/13.0-16-s": {
+		"category": "not_es3"
+	},
+	"language/statements/function/13.0-7-s": {
+		"category": "not_es3"
+	},
+	"language/statements/function/13.1-15-s": {
+		"category": "not_es3"
+	},
+	"language/statements/function/13.1-16-s": {
+		"category": "not_es3"
+	},
+	"language/statements/function/13.1-17-s": {
+		"category": "not_es3"
+	},
+	"language/statements/function/13.1-18-s": {
+		"category": "not_es3"
+	},
+	"language/statements/function/13.1-19-s": {
+		"category": "not_es3"
+	},
+	"language/statements/function/13.1-20-s": {
+		"category": "not_es3"
+	},
+	"language/statements/function/13.1-21-s": {
+		"category": "not_es3"
+	},
+	"language/statements/function/13.1-22-s": {
+		"category": "not_es3"
+	},
+	"language/statements/function/13.1-23-s": {
+		"category": "not_es3"
+	},
+	"language/statements/function/13.1-24-s": {
+		"category": "not_es3"
+	},
+	"language/statements/function/13.1-25-s": {
+		"category": "not_es3"
+	},
+	"language/statements/function/13.1-26-s": {
+		"category": "not_es3"
+	},
+	"language/statements/function/13.1-27-s": {
+		"category": "not_es3"
+	},
+	"language/statements/function/13.1-28-s": {
+		"category": "not_es3"
+	},
+	"language/statements/function/13.1-29-s": {
+		"category": "not_es3"
+	},
+	"language/statements/function/13.1-30-s": {
+		"category": "not_es3"
+	},
+	"language/statements/function/13.1-31-s": {
+		"category": "not_es3"
+	},
+	"language/statements/function/13.1-32-s": {
+		"category": "not_es3"
+	},
+	"language/statements/function/13.1-33-s": {
+		"category": "not_es3"
+	},
+	"language/statements/function/13.1-34-s": {
+		"category": "not_es3"
+	},
+	"language/statements/function/13.1-35-s": {
+		"category": "not_es3"
+	},
+	"language/statements/function/13.1-36-s": {
+		"category": "not_es3"
+	},
+	"language/statements/function/13.1-37-s": {
+		"category": "not_es3"
+	},
+	"language/statements/function/13.1-38-s": {
+		"category": "not_es3"
+	},
+	"language/statements/function/13.1-39-s": {
+		"category": "not_es3"
+	},
+	"language/statements/function/13.1-40-s": {
+		"category": "not_es3"
+	},
+	"language/statements/function/13.1-41-s": {
+		"category": "not_es3"
+	},
+	"language/statements/function/13.1-42-s": {
+		"category": "not_es3"
+	},
+	"language/statements/function/13.2-10-s": {
+		"category": "not_es3"
+	},
+	"language/statements/function/13.2-13-s": {
+		"category": "not_es3"
+	},
+	"language/statements/function/13.2-14-s": {
+		"category": "not_es3"
+	},
+	"language/statements/function/13.2-15-1": {
+		"category": "tbd"
+	},
+	"language/statements/function/13.2-17-1": {
+		"category": "tbd"
+	},
+	"language/statements/function/13.2-17-s": {
+		"category": "not_es3"
+	},
+	"language/statements/function/13.2-18-1": {
+		"category": "not_es3"
+	},
+	"language/statements/function/13.2-18-s": {
+		"category": "not_es3"
+	},
+	"language/statements/function/13.2-21-s": {
+		"category": "not_es3"
+	},
+	"language/statements/function/13.2-22-s": {
+		"category": "not_es3"
+	},
+	"language/statements/function/13.2-25-s": {
+		"category": "not_es3"
+	},
+	"language/statements/function/13.2-26-s": {
 		"category": "not_es3"
 	},
 	"language/statements/function/13.2-30-s": {
 		"category": "not_es3"
 	},
+	"language/statements/function/13.2-5-s": {
+		"category": "not_es3"
+	},
+	"language/statements/function/13.2-6-s": {
+		"category": "not_es3"
+	},
+	"language/statements/function/13.2-9-s": {
+		"category": "not_es3"
+	},
+	"language/statements/function/S13.2.1_A1_T1": {
+		"category": "by_design"
+	},
 	"language/statements/function/name": {
 		"category": "not_es3"
 	},
-	"annexB/built-ins/Date/prototype/getYear/B.2.4": {
+	"language/statements/generators/declaration": {
+		"category": "not_es3"
+	},
+	"language/statements/generators/has-instance": {
+		"category": "not_es3"
+	},
+	"language/statements/generators/invoke-as-constructor": {
+		"category": "not_es3"
+	},
+	"language/statements/generators/length-property-descriptor": {
+		"category": "not_es3"
+	},
+	"language/statements/generators/name": {
+		"category": "not_es3"
+	},
+	"language/statements/generators/no-yield": {
+		"category": "not_es3"
+	},
+	"language/statements/generators/prototype-own-properties": {
+		"category": "not_es3"
+	},
+	"language/statements/generators/prototype-property-descriptor": {
+		"category": "not_es3"
+	},
+	"language/statements/generators/prototype-relation-to-function": {
+		"category": "not_es3"
+	},
+	"language/statements/generators/prototype-typeof": {
+		"category": "not_es3"
+	},
+	"language/statements/generators/prototype-uniqueness": {
+		"category": "not_es3"
+	},
+	"language/statements/generators/prototype-value": {
+		"category": "not_es3"
+	},
+	"language/statements/generators/restricted-properties": {
+		"category": "not_es3"
+	},
+	"language/statements/generators/return": {
+		"category": "not_es3"
+	},
+	"language/statements/generators/yield-as-expression-with-rhs": {
+		"category": "not_es3"
+	},
+	"language/statements/generators/yield-as-expression-without-rhs": {
+		"category": "not_es3"
+	},
+	"language/statements/generators/yield-as-function-expression-binding-identifier": {
+		"category": "not_es3"
+	},
+	"language/statements/generators/yield-as-generator-declaration-binding-identifier": {
+		"category": "not_es3"
+	},
+	"language/statements/generators/yield-as-identifier-in-nested-function": {
+		"category": "not_es3"
+	},
+	"language/statements/generators/yield-as-literal-property-name": {
+		"category": "not_es3"
+	},
+	"language/statements/generators/yield-as-property-name": {
+		"category": "not_es3"
+	},
+	"language/statements/generators/yield-as-statement": {
+		"category": "not_es3"
+	},
+	"language/statements/generators/yield-as-yield-operand": {
+		"category": "not_es3"
+	},
+	"language/statements/generators/yield-newline": {
+		"category": "not_es3"
+	},
+	"language/statements/generators/yield-star-before-newline": {
+		"category": "not_es3"
+	},
+	"language/statements/if/cptn-else-false-abrupt-empty": {
+		"category": "not_es3"
+	},
+	"language/statements/if/cptn-else-false-nrml": {
+		"category": "not_es3"
+	},
+	"language/statements/if/cptn-else-true-abrupt-empty": {
+		"category": "not_es3"
+	},
+	"language/statements/if/cptn-else-true-nrml": {
+		"category": "not_es3"
+	},
+	"language/statements/if/cptn-no-else-false": {
+		"category": "not_es3"
+	},
+	"language/statements/if/cptn-no-else-true-abrupt-empty": {
+		"category": "not_es3"
+	},
+	"language/statements/if/cptn-no-else-true-nrml": {
+		"category": "not_es3"
+	},
+	"language/statements/let/block-local-closure-get-before-initialization": {
+		"category": "not_es3"
+	},
+	"language/statements/let/block-local-closure-set-before-initialization": {
+		"category": "not_es3"
+	},
+	"language/statements/let/block-local-use-before-initialization-in-declaration-statement": {
+		"category": "not_es3"
+	},
+	"language/statements/let/block-local-use-before-initialization-in-prior-statement": {
+		"category": "not_es3"
+	},
+	"language/statements/let/fn-name-arrow": {
+		"category": "not_es3"
+	},
+	"language/statements/let/fn-name-class": {
+		"category": "not_es3"
+	},
+	"language/statements/let/fn-name-cover": {
+		"category": "not_es3"
+	},
+	"language/statements/let/fn-name-fn": {
+		"category": "not_es3"
+	},
+	"language/statements/let/fn-name-gen": {
+		"category": "not_es3"
+	},
+	"language/statements/let/function-local-closure-get-before-initialization": {
+		"category": "not_es3"
+	},
+	"language/statements/let/function-local-closure-set-before-initialization": {
+		"category": "not_es3"
+	},
+	"language/statements/let/function-local-use-before-initialization-in-declaration-statement": {
+		"category": "not_es3"
+	},
+	"language/statements/let/function-local-use-before-initialization-in-prior-statement": {
+		"category": "not_es3"
+	},
+	"language/statements/let/global-closure-get-before-initialization": {
+		"category": "not_es3"
+	},
+	"language/statements/let/global-closure-set-before-initialization": {
+		"category": "not_es3"
+	},
+	"language/statements/let/global-use-before-initialization-in-declaration-statement": {
+		"category": "not_es3"
+	},
+	"language/statements/let/global-use-before-initialization-in-prior-statement": {
+		"category": "not_es3"
+	},
+	"language/statements/let/syntax/let": {
+		"category": "not_es3"
+	},
+	"language/statements/let/syntax/let-closure-inside-condition": {
+		"category": "not_es3"
+	},
+	"language/statements/let/syntax/let-closure-inside-initialization": {
+		"category": "not_es3"
+	},
+	"language/statements/let/syntax/let-closure-inside-next-expression": {
+		"category": "not_es3"
+	},
+	"language/statements/let/syntax/let-iteration-variable-is-freshly-allocated-for-each-iteration-multi-let-binding": {
+		"category": "not_es3"
+	},
+	"language/statements/let/syntax/let-iteration-variable-is-freshly-allocated-for-each-iteration-single-let-binding": {
+		"category": "not_es3"
+	},
+	"language/statements/let/syntax/let-let-declaration-split-across-two-lines": {
+		"category": "not_es3"
+	},
+	"language/statements/let/syntax/let-let-declaration-with-initializer-split-across-two-lines": {
+		"category": "not_es3"
+	},
+	"language/statements/let/syntax/let-outer-inner-let-bindings": {
+		"category": "not_es3"
+	},
+	"language/statements/let/syntax/with-initialisers-in-statement-positions-case-expression-statement-list": {
+		"category": "not_es3"
+	},
+	"language/statements/let/syntax/with-initialisers-in-statement-positions-default-statement-list": {
+		"category": "not_es3"
+	},
+	"language/statements/let/syntax/without-initialisers-in-statement-positions-case-expression-statement-list": {
+		"category": "not_es3"
+	},
+	"language/statements/let/syntax/without-initialisers-in-statement-positions-default-statement-list": {
+		"category": "not_es3"
+	},
+	"language/statements/switch/cptn-a-abrupt-empty": {
+		"category": "not_es3"
+	},
+	"language/statements/switch/cptn-abrupt-empty": {
+		"category": "not_es3"
+	},
+	"language/statements/switch/cptn-b-abrupt-empty": {
+		"category": "not_es3"
+	},
+	"language/statements/switch/cptn-b-final": {
+		"category": "not_es3"
+	},
+	"language/statements/switch/cptn-dflt-abrupt-empty": {
+		"category": "not_es3"
+	},
+	"language/statements/switch/cptn-dflt-b-abrupt-empty": {
+		"category": "not_es3"
+	},
+	"language/statements/switch/cptn-dflt-b-final": {
+		"category": "not_es3"
+	},
+	"language/statements/switch/cptn-dflt-final": {
+		"category": "not_es3"
+	},
+	"language/statements/switch/cptn-no-dflt-match-abrupt-empty": {
+		"category": "not_es3"
+	},
+	"language/statements/switch/cptn-no-dflt-match-final": {
+		"category": "not_es3"
+	},
+	"language/statements/switch/cptn-no-dflt-no-match": {
+		"category": "not_es3"
+	},
+	"language/statements/try/cptn-catch": {
+		"category": "not_es3"
+	},
+	"language/statements/try/cptn-finally-from-catch": {
+		"category": "not_es3"
+	},
+	"language/statements/try/cptn-finally-skip-catch": {
+		"category": "not_es3"
+	},
+	"language/statements/try/cptn-finally-wo-catch": {
+		"category": "not_es3"
+	},
+	"language/statements/try/cptn-try": {
+		"category": "not_es3"
+	},
+	"language/statements/variable/12.2.1-22-s": {
+		"category": "not_es3"
+	},
+	"language/statements/variable/fn-name-arrow": {
+		"category": "not_es3"
+	},
+	"language/statements/variable/fn-name-class": {
+		"category": "not_es3"
+	},
+	"language/statements/variable/fn-name-cover": {
+		"category": "not_es3"
+	},
+	"language/statements/variable/fn-name-fn": {
+		"category": "not_es3"
+	},
+	"language/statements/variable/fn-name-gen": {
+		"category": "not_es3"
+	},
+	"language/statements/while/cptn-abrupt-empty": {
+		"category": "not_es3"
+	},
+	"language/statements/while/cptn-iter": {
+		"category": "not_es3"
+	},
+	"language/statements/while/cptn-no-iter": {
+		"category": "not_es3"
+	},
+	"language/statements/while/labeled-fn-stmt": {
+		"category": "by_design"
+	},
+	"language/statements/with/12.10.1-1-s": {
+		"category": "not_es3"
+	},
+	"language/statements/with/12.10.1-12-s": {
+		"category": "not_es3"
+	},
+	"language/statements/with/12.10.1-2-s": {
+		"category": "not_es3"
+	},
+	"language/statements/with/12.10.1-3-s": {
+		"category": "not_es3"
+	},
+	"language/statements/with/12.10.1-4-s": {
+		"category": "not_es3"
+	},
+	"language/statements/with/12.10.1-8-s": {
+		"category": "not_es3"
+	},
+	"language/statements/with/12.10.1-9-s": {
+		"category": "not_es3"
+	},
+	"language/statements/with/binding-blocked-by-unscopables": {
+		"category": "not_es3"
+	},
+	"language/statements/with/binding-not-blocked-by-unscopables-falsey-prop": {
+		"category": "not_es3"
+	},
+	"language/statements/with/binding-not-blocked-by-unscopables-non-obj": {
+		"category": "not_es3"
+	},
+	"language/statements/with/cptn-abrupt-empty": {
+		"category": "not_es3"
+	},
+	"language/statements/with/cptn-nrml": {
+		"category": "not_es3"
+	},
+	"language/statements/with/unscopables-get-err": {
+		"category": "not_es3"
+	},
+	"language/statements/with/unscopables-not-referenced-for-undef": {
+		"category": "not_es3"
+	},
+	"language/statements/with/unscopables-prop-get-err": {
+		"category": "not_es3"
+	},
+	"language/types/object/S8.6.2_A8": {
+		"category": "not_es3"
+	},
+	"language/types/reference/8.7.2-7-s": {
+		"category": "not_es3"
+	},
+	"language/types/string/S8.4_A7.2": {
 		"category": ""
 	},
-	"annexB/built-ins/Date/prototype/getYear/B.2.4.propertyCheck": {
+	"language/types/string/S8.4_A7.3": {
 		"category": ""
 	},
-	"annexB/built-ins/Date/prototype/getYear/length": {
+	"language/types/string/S8.4_A7.4": {
 		"category": ""
 	},
-	"annexB/built-ins/Date/prototype/getYear/name": {
+	"language/white-space/S7.2_A1.5_T1": {
 		"category": ""
-	},
-	"annexB/built-ins/Date/prototype/setYear/B.2.5": {
-		"category": ""
-	},
-	"annexB/built-ins/Date/prototype/setYear/B.2.5.propertyCheck": {
-		"category": ""
-	},
-	"annexB/built-ins/Date/prototype/setYear/length": {
-		"category": ""
-	},
-	"annexB/built-ins/Date/prototype/setYear/name": {
-		"category": ""
-	},
-	"annexB/built-ins/Date/prototype/toGMTString/B.2.6": {
-		"category": ""
-	},
-	"annexB/built-ins/Date/prototype/toGMTString/B.2.6.propertyCheck": {
-		"category": ""
-	},
-	"annexB/built-ins/Date/prototype/toGMTString/length": {
-		"category": ""
-	},
-	"annexB/built-ins/Date/prototype/toGMTString/name": {
-		"category": ""
-	},
-	"annexB/built-ins/Object/prototype/__proto__/B.2.2.1.1": {
-		"category": "not_es3"
-	},
-	"annexB/built-ins/Object/prototype/__proto__/B.2.2.1.2": {
-		"category": "not_es3"
-	},
-	"annexB/built-ins/RegExp/RegExp-control-escape-russian-letter": {
-		"category": "not_es3"
-	},
-	"annexB/built-ins/RegExp/RegExp-decimal-escape-class-range": {
-		"category": "not_es3"
-	},
-	"annexB/built-ins/RegExp/RegExp-decimal-escape-not-capturing": {
-		"category": "not_es3"
-	},
-	"annexB/built-ins/RegExp/RegExp-leading-escape-BMP": {
-		"category": "not_es3"
-	},
-	"annexB/built-ins/RegExp/RegExp-leading-escape": {
-		"category": "not_es3"
-	},
-	"annexB/built-ins/RegExp/RegExp-trailing-escape-BMP": {
-		"category": "not_es3"
-	},
-	"annexB/built-ins/RegExp/RegExp-trailing-escape": {
-		"category": "not_es3"
-	},
-	"annexB/built-ins/RegExp/prototype/compile/B.RegExp.prototype.compile": {
-		"category": "not_es3"
-	},
-	"annexB/built-ins/RegExp/prototype/compile/length": {
-		"category": "not_es3"
-	},
-	"annexB/built-ins/RegExp/prototype/compile/name": {
-		"category": "not_es3"
-	},
-	"annexB/built-ins/String/prototype/substr/B.2.3": {
-		"category": "not_es3"
-	},
-	"annexB/built-ins/String/prototype/substr/length": {
-		"category": "not_es3"
-	},
-	"annexB/built-ins/String/prototype/substr/name": {
-		"category": "not_es3"
-	},
-	"annexB/built-ins/escape/B.2.1": {
-		"category": "not_es3"
-	},
-	"annexB/built-ins/escape/B.2.1.propertyCheck": {
-		"category": "not_es3"
-	},
-	"annexB/built-ins/escape/length": {
-		"category": "not_es3"
-	},
-	"annexB/built-ins/escape/name": {
-		"category": "not_es3"
-	},
-	"annexB/built-ins/unescape/B.2.2": {
-		"category": "not_es3"
-	},
-	"annexB/built-ins/unescape/B.2.2.propertyCheck": {
-		"category": "not_es3"
-	},
-	"annexB/built-ins/unescape/length": {
-		"category": "not_es3"
-	},
-	"annexB/built-ins/unescape/name": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/isArray/name": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/of/construct-this-with-the-number-of-arguments": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/of/creates-a-new-array-from-arguments": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/of/does-not-use-prototype-properties": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/of/length": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/of/name": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/of/of": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/of/return-a-custom-instance": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/of/return-a-new-array-object": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/of/return-abrupt-from-contructor": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/of/return-abrupt-from-data-property-using-proxy": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/of/return-abrupt-from-setting-length": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/of/sets-length": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/copyWithin/coerced-values-end": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/copyWithin/coerced-values-start": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/copyWithin/coerced-values-target": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/copyWithin/copyWithin": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/copyWithin/fill-holes": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/copyWithin/length": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/copyWithin/name": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/copyWithin/negative-end": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/copyWithin/negative-out-of-bounds-end": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/copyWithin/negative-out-of-bounds-start": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/copyWithin/negative-out-of-bounds-target": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/copyWithin/negative-start": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/copyWithin/negative-target": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/copyWithin/non-negative-out-of-bounds-end": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/copyWithin/non-negative-out-of-bounds-target-and-start": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/copyWithin/non-negative-target-and-start": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/copyWithin/non-negative-target-start-and-end": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/copyWithin/return-abrupt-from-delete-proxy-target": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/copyWithin/return-abrupt-from-end-as-symbol": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/copyWithin/return-abrupt-from-end": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/copyWithin/return-abrupt-from-get-start-value": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/copyWithin/return-abrupt-from-has-start": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/copyWithin/return-abrupt-from-set-target-value": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/copyWithin/return-abrupt-from-start-as-symbol": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/copyWithin/return-abrupt-from-start": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/copyWithin/return-abrupt-from-target-as-symbol": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/copyWithin/return-abrupt-from-target": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/copyWithin/return-abrupt-from-this-length-as-symbol": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/copyWithin/return-abrupt-from-this-length": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/copyWithin/return-this": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/copyWithin/undefined-end": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/entries/entries": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/entries/iteration-mutable": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/entries/iteration": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/entries/length": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/entries/name": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/entries/returns-iterator-from-object": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/entries/returns-iterator": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-0-1": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-0-2": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-1-10": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-1-11": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-1-12": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-1-13": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-1-14": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-1-15": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-1-3": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-1-4": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-1-5": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-1-6": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-1-7": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-1-8": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-1-9": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-2-1": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-2-10": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-2-11": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-2-12": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-2-13": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-2-14": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-2-15": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-2-17": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-2-18": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-2-19": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-2-2": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-2-3": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-2-4": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-2-5": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-2-6": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-2-7": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-2-8": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-2-9": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-3-1": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-3-10": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-3-11": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-3-12": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-3-13": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-3-14": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-3-15": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-3-16": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-3-17": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-3-18": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-3-19": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-3-2": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-3-20": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-3-21": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-3-22": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-3-23": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-3-24": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-3-25": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-3-29": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-3-3": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-3-4": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-3-5": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-3-6": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-3-7": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-3-8": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-3-9": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-4-10": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-4-11": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-4-12": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-4-15": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-4-8": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-4-9": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-5-1-s": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-5-1": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-5-10": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-5-11": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-5-12": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-5-13": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-5-14": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-5-15": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-5-16": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-5-17": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-5-18": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-5-19": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-5-2": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-5-21": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-5-22": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-5-23": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-5-24": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-5-3": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-5-4": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-5-5": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-5-6": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-5-7": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-5-9": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-1": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-2": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-3": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-4": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-5": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-6": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-7": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-8": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-9": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-b-1": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-b-10": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-b-11": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-b-12": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-b-13": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-b-14": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-b-15": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-b-16": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-b-2": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-b-3": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-b-4": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-b-5": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-b-6": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-b-7": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-b-8": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-b-9": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-i-1": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-i-10": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-i-11": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-i-12": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-i-13": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-i-14": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-i-15": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-i-16": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-i-17": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-i-18": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-i-19": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-i-2": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-i-20": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-i-21": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-i-22": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-i-23": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-i-25": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-i-26": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-i-27": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-i-28": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-i-29": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-i-3": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-i-30": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-i-31": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-i-4": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-i-5": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-i-6": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-i-7": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-i-8": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-i-9": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-ii-1": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-ii-10": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-ii-11": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-ii-12": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-ii-13": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-ii-16": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-ii-17": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-ii-18": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-ii-19": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-ii-2": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-ii-20": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-ii-21": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-ii-22": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-ii-23": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-ii-3": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-ii-4": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-ii-5": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-ii-6": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-ii-7": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-ii-8": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-ii-9": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-iii-1": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-iii-10": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-iii-11": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-iii-12": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-iii-13": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-iii-14": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-iii-15": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-iii-16": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-iii-17": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-iii-18": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-iii-19": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-iii-2": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-iii-20": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-iii-21": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-iii-22": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-iii-23": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-iii-24": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-iii-25": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-iii-27": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-iii-28": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-iii-29": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-iii-3": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-iii-4": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-iii-5": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-iii-6": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-iii-7": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-iii-8": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-7-c-iii-9": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-8-1": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-8-10": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-8-11": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-8-12": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-8-13": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-8-2": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-8-3": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-8-4": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-8-5": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-8-6": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-8-7": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/15.4.4.16-8-8": {
-		"category": "not_es3"
-	},
-	"built-ins/Array/prototype/every/name": {
-		"category": "not_es3"
-	},
-		"built-ins/Object/assign/ObjectOverride-sameproperty": {
-				"category": "not_es3"
-		},
-		"built-ins/Object/assign/OnlyOneArgument": {
-				"category": "not_es3"
-		},
-		"built-ins/Object/assign/Override-notstringtarget": {
-				"category": "not_es3"
-		},
-		"built-ins/Object/assign/Override": {
-				"category": "not_es3"
-		},
-		"built-ins/Object/assign/Source-Null-Undefined": {
-				"category": "not_es3"
-		},
-		"built-ins/Object/assign/Source-Number-Boolen-Symbol": {
-				"category": "not_es3"
-		},
-		"built-ins/Object/assign/Source-String": {
-				"category": "not_es3"
-		},
-		"built-ins/Object/assign/Target-Boolean": {
-				"category": "not_es3"
-		},
-		"built-ins/Object/assign/Target-Number": {
-				"category": "not_es3"
-		},
-		"built-ins/Object/assign/Target-Object": {
-				"category": "not_es3"
-		},
-		"built-ins/Object/assign/Target-String": {
-				"category": "not_es3"
-		},
-		"built-ins/Object/assign/Target-Symbol": {
-				"category": "not_es3"
-		},
-		"built-ins/Object/assign/assign-descriptor": {
-				"category": "not_es3"
-		},
-		"built-ins/Object/assign/assign-length": {
-				"category": "not_es3"
-		},
-		"built-ins/Object/assign/name": {
-				"category": "not_es3"
-		},
-		"built-ins/Object/assign/source-get-attr-error": {
-				"category": "not_es3"
-		},
-		"built-ins/Object/assign/source-non-enum": {
-				"category": "not_es3"
-		},
-		"built-ins/Object/assign/source-own-prop-desc-missing": {
-				"category": "not_es3"
-		},
-		"built-ins/Object/assign/source-own-prop-error": {
-				"category": "not_es3"
-		},
-		"built-ins/Object/assign/source-own-prop-keys-error": {
-				"category": "not_es3"
-		},
-		"built-ins/Object/assign/target-set-user-error": {
-				"category": "not_es3"
-		},
-		"built-ins/Array/prototype/find/array-altered-during-loop": {
-			"category": "not_es3"
-		},
-		"built-ins/Array/prototype/find/find": {
-			"category": "not_es3"
-		},
-		"built-ins/Array/prototype/find/length": {
-			"category": "not_es3"
-		},
-		"built-ins/Array/prototype/find/name": {
-			"category": "not_es3"
-		},
-		"built-ins/Array/prototype/find/predicate-call-parameters": {
-			"category": "not_es3"
-		},
-		"built-ins/Array/prototype/find/predicate-call-this-non-strict": {
-			"category": "not_es3"
-		},
-		"built-ins/Array/prototype/find/predicate-called-for-each-array-property": {
-			"category": "not_es3"
-		},
-		"built-ins/Array/prototype/find/predicate-not-called-on-empty-array": {
-			"category": "not_es3"
-		},
-		"built-ins/Array/prototype/find/return-abrupt-from-predicate-call": {
-			"category": "not_es3"
-		},
-		"built-ins/Array/prototype/find/return-abrupt-from-property": {
-			"category": "not_es3"
-		},
-		"built-ins/Array/prototype/find/return-abrupt-from-this-length-as-symbol": {
-			"category": "not_es3"
-		},
-		"built-ins/Array/prototype/find/return-abrupt-from-this-length": {
-			"category": "not_es3"
-		},
-		"built-ins/Array/prototype/find/return-found-value-predicate-result-is-true": {
-			"category": "not_es3"
-		},
-		"built-ins/Array/prototype/find/return-undefined-if-predicate-returns-false-value": {
-			"category": "not_es3"
-		},
-		"built-ins/Array/prototype/findIndex/array-altered-during-loop": {
-			"category": "not_es3"
-		},
-		"built-ins/Array/prototype/findIndex/findIndex": {
-			"category": "not_es3"
-		},
-		"built-ins/Array/prototype/findIndex/length": {
-			"category": "not_es3"
-		},
-		"built-ins/Array/prototype/findIndex/name": {
-			"category": "not_es3"
-		},
-		"built-ins/Array/prototype/findIndex/predicate-call-parameters": {
-			"category": "not_es3"
-		},
-		"built-ins/Array/prototype/findIndex/predicate-call-this-non-strict": {
-			"category": "not_es3"
-		},
-		"built-ins/Array/prototype/findIndex/predicate-called-for-each-array-property": {
-			"category": "not_es3"
-		},
-		"built-ins/Array/prototype/findIndex/predicate-not-called-on-empty-array": {
-			"category": "not_es3"
-		},
-		"built-ins/Array/prototype/findIndex/return-abrupt-from-predicate-call": {
-			"category": "not_es3"
-		},
-		"built-ins/Array/prototype/findIndex/return-abrupt-from-property": {
-			"category": "not_es3"
-		},
-		"built-ins/Array/prototype/findIndex/return-abrupt-from-this-length-as-symbol": {
-			"category": "not_es3"
-		},
-		"built-ins/Array/prototype/findIndex/return-abrupt-from-this-length": {
-			"category": "not_es3"
-		},
-		"built-ins/Array/prototype/findIndex/return-index-predicate-result-is-true": {
-			"category": "not_es3"
-		},
-		"built-ins/Array/prototype/findIndex/return-negative-one-if-predicate-returns-false-value": {
-			"category": "not_es3"
-		},
-		"built-ins/Array/prototype/keys/iteration-mutable": {
-			"category": "not_es3"
-		},
-		"built-ins/Array/prototype/keys/iteration": {
-			"category": "not_es3"
-		},
-		"built-ins/Array/prototype/keys/keys": {
-			"category": "not_es3"
-		},
-		"built-ins/Array/prototype/keys/length": {
-			"category": "not_es3"
-		},
-		"built-ins/Array/prototype/keys/name": {
-			"category": "not_es3"
-		},
-		"built-ins/Array/prototype/keys/returns-iterator-from-object": {
-			"category": "not_es3"
-		},
-		"built-ins/Array/prototype/keys/returns-iterator": {
-			"category": "not_es3"
-		},
-		"built-ins/Array/prototype/values/iteration-mutable": {
-			"category": "not_es3"
-		},
-		"built-ins/Array/prototype/values/iteration": {
-			"category": "not_es3"
-		},
-		"built-ins/Array/prototype/values/length": {
-			"category": "not_es3"
-		},
-		"built-ins/Array/prototype/values/name": {
-			"category": "not_es3"
-		},
-		"built-ins/Array/prototype/values/prop-desc": {
-			"category": "not_es3"
-		},
-		"built-ins/Array/prototype/values/returns-iterator-from-object": {
-			"category": "not_es3"
-		},
-		"built-ins/Array/prototype/values/returns-iterator": {
-			"category": "not_es3"
-		},
-		"built-ins/Array/prototype/Symbol.iterator": {
-			"category": "not_es3"
-		},
-		"built-ins/Array/prototype/Symbol.unscopables/prop-desc": {
-			"category": "not_es3"
-		},
-		"built-ins/Array/prototype/Symbol.unscopables/value": {
-			"category": "not_es3"
-		},
-		"built-ins/IteratorPrototype/Symbol.iterator/length": {
-			"category": "not_es3"
-		},
-		"built-ins/IteratorPrototype/Symbol.iterator/name": {
-			"category": "not_es3"
-		},
-		"built-ins/IteratorPrototype/Symbol.iterator/prop-desc": {
-			"category": "not_es3"
-		},
-		"built-ins/IteratorPrototype/Symbol.iterator/return-val": {
-			"category": "not_es3"
-		},
-		"built-ins/Map/constructor": {
-			"category": "not_es3"
-		},
-		"built-ins/Map/does-not-throw-when-set-is-not-callable": {
-			"category": "not_es3"
-		},
-		"built-ins/Map/get-set-method-failure": {
-			"category": "not_es3"
-		},
-		"built-ins/Map/iterable-calls-set": {
-			"category": "not_es3"
-		},
-		"built-ins/Map/iterator-close-after-set-failure": {
-			"category": "not_es3"
-		},
-		"built-ins/Map/iterator-item-first-entry-returns-abrupt": {
-			"category": "not_es3"
-		},
-		"built-ins/Map/iterator-item-second-entry-returns-abrupt": {
-			"category": "not_es3"
-		},
-		"built-ins/Map/iterator-items-are-not-object-close-iterator": {
-			"category": "not_es3"
-		},
-		"built-ins/Map/iterator-items-are-not-object": {
-			"category": "not_es3"
-		},
-		"built-ins/Map/iterator-next-failure": {
-			"category": "not_es3"
-		},
-		"built-ins/Map/iterator-value-failure": {
-			"category": "not_es3"
-		},
-		"built-ins/Map/length": {
-			"category": "not_es3"
-		},
-		"built-ins/Map/map-iterable-empty-does-not-call-set": {
-			"category": "not_es3"
-		},
-		"built-ins/Map/map-iterable-throws-when-set-is-not-callable": {
-			"category": "not_es3"
-		},
-		"built-ins/Map/map-iterable": {
-			"category": "not_es3"
-		},
-		"built-ins/Map/map-no-iterable-does-not-call-set": {
-			"category": "not_es3"
-		},
-		"built-ins/Map/map-no-iterable": {
-			"category": "not_es3"
-		},
-		"built-ins/Map/map": {
-			"category": "not_es3"
-		},
-		"built-ins/Map/name": {
-			"category": "not_es3"
-		},
-		"built-ins/Map/newtarget": {
-			"category": "not_es3"
-		},
-		"built-ins/Map/properties-of-map-instances": {
-			"category": "not_es3"
-		},
-		"built-ins/Map/properties-of-the-map-prototype-object": {
-			"category": "not_es3"
-		},
-		"built-ins/Map/prototype-of-map": {
-			"category": "not_es3"
-		},
-		"built-ins/Map/symbol-as-entry-key": {
-			"category": "not_es3"
-		},
-		"built-ins/Map/undefined-newtarget": {
-			"category": "not_es3"
-		},
-		"built-ins/Map/Symbol.species/length": {
-			"category": "not_es3"
-		},
-		"built-ins/Map/Symbol.species/symbol-species-name": {
-			"category": "not_es3"
-		},
-		"built-ins/Map/Symbol.species/symbol-species": {
-			"category": "not_es3"
-		},
-		"built-ins/Map/prototype/Symbol.iterator": {
-			"category": "not_es3"
-		},
-		"built-ins/Map/prototype/Symbol.toStringTag": {
-			"category": "not_es3"
-		},
-		"built-ins/Map/prototype/constructor": {
-			"category": "not_es3"
-		},
-		"built-ins/Map/prototype/descriptor": {
-			"category": "not_es3"
-		},
-		"built-ins/Set/constructor": {
-			"category": "not_es3"
-		},
-		"built-ins/Set/length": {
-			"category": "not_es3"
-		},
-		"built-ins/Set/name": {
-			"category": "not_es3"
-		},
-		"built-ins/Set/properties-of-the-set-prototype-object": {
-			"category": "not_es3"
-		},
-		"built-ins/Set/prototype-of-set": {
-			"category": "not_es3"
-		},
-		"built-ins/Set/set-does-not-throw-when-add-is-not-callable": {
-			"category": "not_es3"
-		},
-		"built-ins/Set/set-get-add-method-failure": {
-			"category": "not_es3"
-		},
-		"built-ins/Set/set-iterable-calls-add": {
-			"category": "not_es3"
-		},
-		"built-ins/Set/set-iterable-empty-does-not-call-add": {
-			"category": "not_es3"
-		},
-		"built-ins/Set/set-iterable-throws-when-add-is-not-callable": {
-			"category": "not_es3"
-		},
-		"built-ins/Set/set-iterable": {
-			"category": "not_es3"
-		},
-		"built-ins/Set/set-iterator-close-after-add-failure": {
-			"category": "not_es3"
-		},
-		"built-ins/Set/set-iterator-next-failure": {
-			"category": "not_es3"
-		},
-		"built-ins/Set/set-iterator-value-failure": {
-			"category": "not_es3"
-		},
-		"built-ins/Set/set-newtarget": {
-			"category": "not_es3"
-		},
-		"built-ins/Set/set-no-iterable": {
-			"category": "not_es3"
-		},
-		"built-ins/Set/set-undefined-newtarget": {
-			"category": "not_es3"
-		},
-		"built-ins/Set/set": {
-			"category": "not_es3"
-		},
-		"built-ins/Set/symbol-as-entry": {
-			"category": "not_es3"
-		},
-		"built-ins/Set/Symbol.species/length": {
-			"category": "not_es3"
-		},
-		"built-ins/Set/Symbol.species/symbol-species-name": {
-			"category": "not_es3"
-		},
-		"built-ins/Set/Symbol.species/symbol-species": {
-			"category": "not_es3"
-		},
-		"built-ins/Set/prototype/Symbol.iterator": {
-			"category": "not_es3"
-		},
-		"built-ins/Set/prototype/Symbol.toStringTag": {
-			"category": "not_es3"
-		},
-		"built-ins/Set/prototype/set-prototype": {
-			"category": "not_es3"
-		},
-		"built-ins/Set/prototype/Symbol.toStringTag/property-descriptor": {
-			"category": "not_es3"
-		}
+	}
 }


### PR DESCRIPTION
## Summary
- categorize failing test262 built-in tests like Array.prototype.find/findIndex and Map/Set constructors as not ES3

## Testing
- `timeout 180 ./build.sh` *(fails: arrayIndexTooLarge.io, hexLiteralOverflow.io, hugeDecimalExponent.io)*

------
https://chatgpt.com/codex/tasks/task_e_68b846cd49448332bd2a363c46553f2e