### PR TITLE
Mark ES5 helper tests as bad

### DIFF
--- a/docs/notes/ES3TestFailures.md
+++ b/docs/notes/ES3TestFailures.md
@@ -1,6 +1,6 @@
 # ES3 Test262 Failures Analysis
 
-This report enumerates the remaining 163 Test262 failures that exercise ECMAScript 3 features. Tests for later ECMAScript editions (e.g. Map/Set iterators) are excluded. 140 failing tests for the optional URI encoding helpers (`decodeURI`, `decodeURIComponent`, `encodeURI`, `encodeURIComponent`) are intentionally omitted and listed separately as by design. Each section lists failing tests and explains why their functionality is expected in an ES3-compliant engine.
+This report enumerates the remaining 114 Test262 failures that exercise ECMAScript 3 features. Tests for later ECMAScript editions (e.g. Map/Set iterators) are excluded. 140 failing tests for the optional URI encoding helpers (`decodeURI`, `decodeURIComponent`, `encodeURI`, `encodeURIComponent`) are intentionally omitted and listed separately as by design. Each section lists failing tests and explains why their functionality is expected in an ES3-compliant engine.
 
 ### Automated classification
 
@@ -10,7 +10,7 @@ Current summary:
 
 | Feature | Spec Clause | Total | non_es3 | Remaining |
 | --- | --- | ---:| ---:| ---:|
-| Array | §15.4 | 17 | 0 | 17 |
+| Array | §15.4 | 12 | 0 | 12 |
 | Date | §15.9 | 7 | 0 | 7 |
 | Error |  | 5 | 0 | 5 |
 | Function |  | 1 | 0 | 1 |
@@ -20,15 +20,15 @@ Current summary:
 | Number | §15.7 | 3 | 0 | 3 |
 | Object | §15.2 | 16 | 0 | 16 |
 | RegExp | §15.10 | 18 | 0 | 18 |
-| String | §15.5 | 73 | 0 | 73 |
-| eval |  | 2 | 0 | 2 |
+| String | §15.5 | 35 | 0 | 35 |
+| eval |  | 1 | 0 | 1 |
 | global |  | 3 | 0 | 3 |
-| isFinite |  | 2 | 0 | 2 |
-| isNaN |  | 2 | 0 | 2 |
-| parseFloat |  | 3 | 0 | 3 |
-| parseInt |  | 5 | 0 | 5 |
-| undefined |  | 2 | 0 | 2 |
-Progress: 163/163 tests reviewed.
+| isFinite |  | 1 | 0 | 1 |
+| isNaN |  | 1 | 0 | 1 |
+| parseFloat |  | 2 | 0 | 2 |
+| parseInt |  | 4 | 0 | 4 |
+| undefined |  | 1 | 0 | 1 |
+Progress: 114/114 tests reviewed.
 
 ### By design (optional URI helpers)
 
@@ -39,22 +39,70 @@ Progress: 163/163 tests reviewed.
 - encodeURI – 22 tests
 - encodeURIComponent – 22 tests
 
+### Bad tests (ES5-only helper)
 
+The following tests rely on the ES5 `Object.getOwnPropertyDescriptor` helper and are marked `bad_test`:
 
-## Array (17 tests)
+- built-ins/Array/S15.4.3_A2.3
+- built-ins/Array/prototype/S15.4.3.1_A3
+- built-ins/Array/prototype/S15.4.3.1_A4
+- built-ins/Array/prototype/concat/S15.4.4.4_A4.3
+- built-ins/Array/prototype/join/S15.4.4.5_A6.3
+- built-ins/String/fromCharCode/name
+- built-ins/String/prototype/S15.5.3.1_A3
+- built-ins/String/prototype/S15.5.3.1_A4
+- built-ins/String/prototype/charAt/S15.5.4.4_A10
+- built-ins/String/prototype/charAt/name
+- built-ins/String/prototype/charCodeAt/S15.5.4.5_A10
+- built-ins/String/prototype/charCodeAt/name
+- built-ins/String/prototype/concat/S15.5.4.6_A10
+- built-ins/String/prototype/concat/name
+- built-ins/String/prototype/indexOf/S15.5.4.7_A10
+- built-ins/String/prototype/indexOf/name
+- built-ins/String/prototype/lastIndexOf/S15.5.4.8_A10
+- built-ins/String/prototype/lastIndexOf/name
+- built-ins/String/prototype/localeCompare/S15.5.4.9_A10
+- built-ins/String/prototype/localeCompare/name
+- built-ins/String/prototype/match/length
+- built-ins/String/prototype/match/name
+- built-ins/String/prototype/replace/S15.5.4.11_A10
+- built-ins/String/prototype/replace/name
+- built-ins/String/prototype/search/S15.5.4.12_A10
+- built-ins/String/prototype/search/name
+- built-ins/String/prototype/slice/S15.5.4.13_A10
+- built-ins/String/prototype/slice/name
+- built-ins/String/prototype/split/S15.5.4.14_A10
+- built-ins/String/prototype/split/name
+- built-ins/String/prototype/substring/S15.5.4.15_A10
+- built-ins/String/prototype/substring/name
+- built-ins/String/prototype/toLocaleLowerCase/S15.5.4.17_A10
+- built-ins/String/prototype/toLocaleLowerCase/name
+- built-ins/String/prototype/toLocaleUpperCase/S15.5.4.19_A10
+- built-ins/String/prototype/toLocaleUpperCase/name
+- built-ins/String/prototype/toLowerCase/S15.5.4.16_A10
+- built-ins/String/prototype/toLowerCase/name
+- built-ins/String/prototype/toString/name
+- built-ins/String/prototype/toUpperCase/S15.5.4.18_A10
+- built-ins/String/prototype/toUpperCase/name
+- built-ins/String/prototype/valueOf/length
+- built-ins/String/prototype/valueOf/name
+- built-ins/eval/S15.1.2.1_A4.3
+- built-ins/isFinite/S15.1.2.5_A2.3
+- built-ins/isNaN/S15.1.2.4_A2.3
+- built-ins/parseFloat/S15.1.2.3_A7.3
+- built-ins/parseInt/S15.1.2.2_A9.3
+- built-ins/undefined/S15.1.1.3_A3_T1
+
+These are excluded from the failure counts below.
+
+## Array (12 tests)
 
 Array construction and prototype methods like `concat`, `join`, `pop`, `push`, `reverse`, `shift`, `slice`, `sort`, `splice`, `toLocaleString`, `toString`, and `unshift` are part of ES3. Failures here indicate missing core array semantics.
-
-- built-ins/Array/S15.4.3_A2.3 — `Array.length` remains writable even though ES3 §15.3.5.1 requires this property to be read-only.
 - built-ins/Array/S15.4.5.1_A2.1_T1 — assigning to keys 4294967295, -1, or `true` should not grow the array (§15.4.5.1), yet NuXJS increments `length`.
 - built-ins/Array/S15.4_A1.1_T1 — boolean property names must not be treated as array indices (§15.4); the engine treats `true`/`false` as numeric indexes.
-- built-ins/Array/prototype/S15.4.3.1_A3 — `Array.prototype` should be non-configurable and non-deletable (§15.4.3.1), but NuXJS allows deletion.
-- built-ins/Array/prototype/S15.4.3.1_A4 — `Array.prototype` is writable although ES3 (§15.4.3.1) mandates a read-only binding.
- - built-ins/Array/prototype/concat/S15.4.4.4_A4.3 — ES3 §15.4.4.4 requires `concat.length` read-only; NuXJS allows writing.
- - built-ins/Array/prototype/join/S15.4.4.5_A6.3 — ES3 §15.3.5.1 mandates `join.length` be read-only; NuXJS writes to it.
- - built-ins/Array/prototype/pop/S15.4.4.6_A2_T2 — when `length` is NaN, ±Infinity, or non-integer, ES3 §15.4.4.6 should coerce to 0; NuXJS leaves other values.
- - built-ins/Array/prototype/pop/S15.4.4.6_A4_T2 — fails to delete own index when prototype defines same property (§15.4.4.6).
- - built-ins/Array/prototype/push/S15.4.4.7_A2_T2 — with NaN/Infinity `length`, push should coerce via ToUint32 (§15.4.4.7); NuXJS misbehaves.
+- built-ins/Array/prototype/pop/S15.4.4.6_A2_T2 — when `length` is NaN, ±Infinity, or non-integer, ES3 §15.4.4.6 should coerce to 0; NuXJS leaves other values.
+- built-ins/Array/prototype/pop/S15.4.4.6_A4_T2 — fails to delete own index when prototype defines same property (§15.4.4.6).
+- built-ins/Array/prototype/push/S15.4.4.7_A2_T2 — with NaN/Infinity `length`, push should coerce via ToUint32 (§15.4.4.7); NuXJS misbehaves.
 - built-ins/Array/prototype/shift/S15.4.4.9_A3_T3
 - built-ins/Array/prototype/shift/S15.4.4.9_A4_T2
 - built-ins/Array/prototype/sort/S15.4.4.11_A7.2
@@ -74,12 +122,11 @@ Covers the `Date` constructor, parsing, UTC calculations, and numerous getter/se
 - built-ins/Date/TimeClip_negative_zero
 - built-ins/Date/prototype/setFullYear/15.9.5.40_1
 
-## eval (2 tests)
+## eval (1 test)
 
 Validates global `eval` executes code in the current scope as specified by ES3.
 
 - built-ins/eval/S15.1.2.1_A4.2
-- built-ins/eval/S15.1.2.1_A4.3
 
 ## global (3 tests)
 
@@ -89,29 +136,26 @@ Ensures global object properties such as `undefined` are configured per ES3.
 - built-ins/global/S10.2.3_A1.2_T2 — `Infinity` is likewise enumerable even though ES3 marks it as `DontEnum`.
 - built-ins/global/S10.2.3_A1.3_T2 — the global `undefined` property appears in `for...in` loops, contrary to ES3 attribute requirements.
 
-## isFinite (2 tests)
+## isFinite (1 test)
 
 Validates the global `isFinite` converts arguments and determines finiteness per ES3.
 
 - built-ins/isFinite/S15.1.2.5_A2.2 — fails to apply `ToNumber` before testing, so string inputs yield wrong results.
-- built-ins/isFinite/S15.1.2.5_A2.3 — returns `true` for `NaN` or infinities instead of `false`.
 
-## isNaN (2 tests)
+## isNaN (1 test)
 
 Validates the global `isNaN` function's ability to detect NaN values, a core numeric primitive in ES3.
 
 - built-ins/isNaN/S15.1.2.4_A2.2 — argument coercion via `ToNumber` is skipped, misclassifying numeric strings.
-- built-ins/isNaN/S15.1.2.4_A2.3 — some finite numbers incorrectly report `true`.
 
-## parseFloat (3 tests)
+## parseFloat (2 tests)
 
 Ensures `parseFloat` parses numeric strings according to ES3 grammar.
 
 - built-ins/parseFloat/S15.1.2.3_A2_T10 — fails to skip form-feed (`\u000C`) before digits.
 - built-ins/parseFloat/S15.1.2.3_A7.2 — does not recognize the `Infinity` literal.
-- built-ins/parseFloat/S15.1.2.3_A7.3 — misparses signed `Infinity` values.
 
-## parseInt (5 tests)
+## parseInt (4 tests)
 
 Ensures `parseInt` parses integers with proper radix handling per ES3.
 
@@ -119,14 +163,12 @@ Ensures `parseInt` parses integers with proper radix handling per ES3.
 - built-ins/parseInt/S15.1.2.2_A5.2_T2 — mishandles hexadecimal `0x` prefixes.
 - built-ins/parseInt/S15.1.2.2_A7.2_T3 — signed hex strings are parsed incorrectly.
 - built-ins/parseInt/S15.1.2.2_A9.2 — default radix handling for leading zeros is wrong.
-- built-ins/parseInt/S15.1.2.2_A9.3 — leading-zero strings with non-octal digits return `NaN` instead of decimal values.
 
-## undefined (2 tests)
+## undefined (1 test)
 
 Checks that `undefined` is read-only and globally defined.
 
 - built-ins/undefined/15.1.1.3-1 — deleting `undefined` succeeds even though ES3 prohibits removal.
-- built-ins/undefined/S15.1.1.3_A3_T1 — assignments alter `undefined`'s value.
 
 ## Function (1 test)
 
@@ -214,37 +256,20 @@ Covers regular expression syntax and `RegExp.prototype.exec`; ES3 defines the fu
 - built-ins/RegExp/prototype/exec/S15.10.6.2_A1_T4
 - built-ins/RegExp/prototype/exec/S15.10.6.2_A1_T5
 
-## String (73 tests)
+
+## String (35 tests)
 
 Validates the `String` constructor and prototype methods such as `charAt`, `indexOf`, and `slice` per ES3.
 
-- built-ins/String/fromCharCode/name
-- built-ins/String/prototype/S15.5.3.1_A3
-- built-ins/String/prototype/S15.5.3.1_A4
-- built-ins/String/prototype/charAt/S15.5.4.4_A10
 - built-ins/String/prototype/charAt/S15.5.4.4_A9
-- built-ins/String/prototype/charAt/name
-- built-ins/String/prototype/charCodeAt/S15.5.4.5_A10
 - built-ins/String/prototype/charCodeAt/S15.5.4.5_A9
-- built-ins/String/prototype/charCodeAt/name
-- built-ins/String/prototype/concat/S15.5.4.6_A10
 - built-ins/String/prototype/concat/S15.5.4.6_A9
-- built-ins/String/prototype/concat/name
-- built-ins/String/prototype/indexOf/S15.5.4.7_A10
 - built-ins/String/prototype/indexOf/S15.5.4.7_A1_T11
 - built-ins/String/prototype/indexOf/S15.5.4.7_A9
-- built-ins/String/prototype/indexOf/name
-- built-ins/String/prototype/lastIndexOf/S15.5.4.8_A10
 - built-ins/String/prototype/lastIndexOf/S15.5.4.8_A9
-- built-ins/String/prototype/lastIndexOf/name
-- built-ins/String/prototype/localeCompare/S15.5.4.9_A10
 - built-ins/String/prototype/localeCompare/S15.5.4.9_A9
-- built-ins/String/prototype/localeCompare/name
 - built-ins/String/prototype/match/S15.5.4.10_A1_T3
 - built-ins/String/prototype/match/S15.5.4.10_A9
-- built-ins/String/prototype/match/length
-- built-ins/String/prototype/match/name
-- built-ins/String/prototype/replace/S15.5.4.11_A10
 - built-ins/String/prototype/replace/S15.5.4.11_A12
 - built-ins/String/prototype/replace/S15.5.4.11_A1_T11
 - built-ins/String/prototype/replace/S15.5.4.11_A1_T12
@@ -253,42 +278,21 @@ Validates the `String` constructor and prototype methods such as `charAt`, `inde
 - built-ins/String/prototype/replace/S15.5.4.11_A3_T3
 - built-ins/String/prototype/replace/S15.5.4.11_A5_T1
 - built-ins/String/prototype/replace/S15.5.4.11_A9
-- built-ins/String/prototype/replace/name
-- built-ins/String/prototype/search/S15.5.4.12_A10
 - built-ins/String/prototype/search/S15.5.4.12_A9
-- built-ins/String/prototype/search/name
-- built-ins/String/prototype/slice/S15.5.4.13_A10
 - built-ins/String/prototype/slice/S15.5.4.13_A9
-- built-ins/String/prototype/slice/name
-- built-ins/String/prototype/split/S15.5.4.14_A10
 - built-ins/String/prototype/split/S15.5.4.14_A1_T3
 - built-ins/String/prototype/split/S15.5.4.14_A9
-- built-ins/String/prototype/split/name
-- built-ins/String/prototype/substring/S15.5.4.15_A10
 - built-ins/String/prototype/substring/S15.5.4.15_A9
-- built-ins/String/prototype/substring/name
-- built-ins/String/prototype/toLocaleLowerCase/S15.5.4.17_A10
 - built-ins/String/prototype/toLocaleLowerCase/S15.5.4.17_A9
-- built-ins/String/prototype/toLocaleLowerCase/name
 - built-ins/String/prototype/toLocaleLowerCase/special_casing_conditional
 - built-ins/String/prototype/toLocaleLowerCase/supplementary_plane
-- built-ins/String/prototype/toLocaleUpperCase/S15.5.4.19_A10
 - built-ins/String/prototype/toLocaleUpperCase/S15.5.4.19_A9
-- built-ins/String/prototype/toLocaleUpperCase/name
 - built-ins/String/prototype/toLocaleUpperCase/special_casing
 - built-ins/String/prototype/toLocaleUpperCase/supplementary_plane
-- built-ins/String/prototype/toLowerCase/S15.5.4.16_A10
 - built-ins/String/prototype/toLowerCase/S15.5.4.16_A9
-- built-ins/String/prototype/toLowerCase/name
 - built-ins/String/prototype/toLowerCase/special_casing
 - built-ins/String/prototype/toLowerCase/special_casing_conditional
 - built-ins/String/prototype/toLowerCase/supplementary_plane
-- built-ins/String/prototype/toString/name
-- built-ins/String/prototype/toUpperCase/S15.5.4.18_A10
 - built-ins/String/prototype/toUpperCase/S15.5.4.18_A9
-- built-ins/String/prototype/toUpperCase/name
 - built-ins/String/prototype/toUpperCase/special_casing
 - built-ins/String/prototype/toUpperCase/supplementary_plane
-- built-ins/String/prototype/valueOf/length
-- built-ins/String/prototype/valueOf/name
-

--- a/tools/testdash.json
+++ b/tools/testdash.json
@@ -27910,5 +27910,152 @@
 	},
 	"built-ins/encodeURIComponent/S15.1.3.4_A6_T1": {
 		"category": "by_design"
+	},
+	"built-ins/Array/S15.4.3_A2.3": {
+		"category": "bad_test"
+	},
+	"built-ins/Array/prototype/S15.4.3.1_A3": {
+		"category": "bad_test"
+	},
+	"built-ins/Array/prototype/S15.4.3.1_A4": {
+		"category": "bad_test"
+	},
+	"built-ins/Array/prototype/concat/S15.4.4.4_A4.3": {
+		"category": "bad_test"
+	},
+	"built-ins/Array/prototype/join/S15.4.4.5_A6.3": {
+		"category": "bad_test"
+	},
+	"built-ins/String/fromCharCode/name": {
+		"category": "bad_test"
+	},
+	"built-ins/String/prototype/S15.5.3.1_A3": {
+		"category": "bad_test"
+	},
+	"built-ins/String/prototype/S15.5.3.1_A4": {
+		"category": "bad_test"
+	},
+	"built-ins/String/prototype/charAt/S15.5.4.4_A10": {
+		"category": "bad_test"
+	},
+	"built-ins/String/prototype/charAt/name": {
+		"category": "bad_test"
+	},
+	"built-ins/String/prototype/charCodeAt/S15.5.4.5_A10": {
+		"category": "bad_test"
+	},
+	"built-ins/String/prototype/charCodeAt/name": {
+		"category": "bad_test"
+	},
+	"built-ins/String/prototype/concat/S15.5.4.6_A10": {
+		"category": "bad_test"
+	},
+	"built-ins/String/prototype/concat/name": {
+		"category": "bad_test"
+	},
+	"built-ins/String/prototype/indexOf/S15.5.4.7_A10": {
+		"category": "bad_test"
+	},
+	"built-ins/String/prototype/indexOf/name": {
+		"category": "bad_test"
+	},
+	"built-ins/String/prototype/lastIndexOf/S15.5.4.8_A10": {
+		"category": "bad_test"
+	},
+	"built-ins/String/prototype/lastIndexOf/name": {
+		"category": "bad_test"
+	},
+	"built-ins/String/prototype/localeCompare/S15.5.4.9_A10": {
+		"category": "bad_test"
+	},
+	"built-ins/String/prototype/localeCompare/name": {
+		"category": "bad_test"
+	},
+	"built-ins/String/prototype/match/length": {
+		"category": "bad_test"
+	},
+	"built-ins/String/prototype/match/name": {
+		"category": "bad_test"
+	},
+	"built-ins/String/prototype/replace/S15.5.4.11_A10": {
+		"category": "bad_test"
+	},
+	"built-ins/String/prototype/replace/name": {
+		"category": "bad_test"
+	},
+	"built-ins/String/prototype/search/S15.5.4.12_A10": {
+		"category": "bad_test"
+	},
+	"built-ins/String/prototype/search/name": {
+		"category": "bad_test"
+	},
+	"built-ins/String/prototype/slice/S15.5.4.13_A10": {
+		"category": "bad_test"
+	},
+	"built-ins/String/prototype/slice/name": {
+		"category": "bad_test"
+	},
+	"built-ins/String/prototype/split/S15.5.4.14_A10": {
+		"category": "bad_test"
+	},
+	"built-ins/String/prototype/split/name": {
+		"category": "bad_test"
+	},
+	"built-ins/String/prototype/substring/S15.5.4.15_A10": {
+		"category": "bad_test"
+	},
+	"built-ins/String/prototype/substring/name": {
+		"category": "bad_test"
+	},
+	"built-ins/String/prototype/toLocaleLowerCase/S15.5.4.17_A10": {
+		"category": "bad_test"
+	},
+	"built-ins/String/prototype/toLocaleLowerCase/name": {
+		"category": "bad_test"
+	},
+	"built-ins/String/prototype/toLocaleUpperCase/S15.5.4.19_A10": {
+		"category": "bad_test"
+	},
+	"built-ins/String/prototype/toLocaleUpperCase/name": {
+		"category": "bad_test"
+	},
+	"built-ins/String/prototype/toLowerCase/S15.5.4.16_A10": {
+		"category": "bad_test"
+	},
+	"built-ins/String/prototype/toLowerCase/name": {
+		"category": "bad_test"
+	},
+	"built-ins/String/prototype/toString/name": {
+		"category": "bad_test"
+	},
+	"built-ins/String/prototype/toUpperCase/S15.5.4.18_A10": {
+		"category": "bad_test"
+	},
+	"built-ins/String/prototype/toUpperCase/name": {
+		"category": "bad_test"
+	},
+	"built-ins/String/prototype/valueOf/length": {
+		"category": "bad_test"
+	},
+	"built-ins/String/prototype/valueOf/name": {
+		"category": "bad_test"
+	},
+	"built-ins/eval/S15.1.2.1_A4.3": {
+		"category": "bad_test"
+	},
+	"built-ins/isFinite/S15.1.2.5_A2.3": {
+		"category": "bad_test"
+	},
+	"built-ins/isNaN/S15.1.2.4_A2.3": {
+		"category": "bad_test"
+	},
+	"built-ins/parseFloat/S15.1.2.3_A7.3": {
+		"category": "bad_test"
+	},
+	"built-ins/parseInt/S15.1.2.2_A9.3": {
+		"category": "bad_test"
+	},
+	"built-ins/undefined/S15.1.1.3_A3_T1": {
+		"category": "bad_test"
 	}
 }


### PR DESCRIPTION
## Summary
- categorize 49 tests that depend on `Object.getOwnPropertyDescriptor` as `bad_test`
- refresh ES3 failure notes and counts after excluding these invalid tests

## Testing
- `timeout 180 ./build.sh` *(fails: arrayIndexTooLarge.io, hexLiteralOverflow.io, hugeDecimalExponent.io)*

------
https://chatgpt.com/codex/tasks/task_e_68b9bb56cc0c833299816583768b425b