### PR TITLE
Remove not_es3 regression tests

### DIFF
--- a/tests/unconforming/hasOwnPropertyNullThis.io
+++ b/tests/unconforming/hasOwnPropertyNullThis.io
@@ -1,3 +1,0 @@
-> Object.prototype.hasOwnProperty.call(null, "x")
-< false
--

--- a/tests/unconforming/hasOwnPropertyUndefinedThis.io
+++ b/tests/unconforming/hasOwnPropertyUndefinedThis.io
@@ -1,3 +1,0 @@
-> Object.prototype.hasOwnProperty.call(undefined, "x")
-< false
--

--- a/tests/unconforming/isPrototypeOfNullThis.io
+++ b/tests/unconforming/isPrototypeOfNullThis.io
@@ -1,3 +1,0 @@
-> Object.prototype.isPrototypeOf.call(null, {})
-< false
--

--- a/tests/unconforming/isPrototypeOfUndefinedThis.io
+++ b/tests/unconforming/isPrototypeOfUndefinedThis.io
@@ -1,3 +1,0 @@
-> Object.prototype.isPrototypeOf.call(undefined, {})
-< false
--

--- a/tests/unconforming/objectToLocaleStringNullThis.io
+++ b/tests/unconforming/objectToLocaleStringNullThis.io
@@ -1,3 +1,0 @@
-> Object.prototype.toLocaleString.call(null)
-< [object Object]
--

--- a/tests/unconforming/objectToLocaleStringUndefinedThis.io
+++ b/tests/unconforming/objectToLocaleStringUndefinedThis.io
@@ -1,3 +1,0 @@
-> Object.prototype.toLocaleString.call(undefined)
-< [object Object]
--

--- a/tests/unconforming/objectToStringNullUndefinedThis.io
+++ b/tests/unconforming/objectToStringNullUndefinedThis.io
@@ -1,6 +1,0 @@
-> Object.prototype.toString.call(undefined)
-< [object Object]
--
-> Object.prototype.toString.call(null)
-< [object Object]
--

--- a/tests/unconforming/objectValueOfNullUndefinedThis.io
+++ b/tests/unconforming/objectValueOfNullUndefinedThis.io
@@ -1,6 +1,0 @@
-> Object.prototype.valueOf.call(null) === this
-< true
--
-> Object.prototype.valueOf.call(undefined) === this
-< true
--

--- a/tests/unconforming/propertyIsEnumerableNullThis.io
+++ b/tests/unconforming/propertyIsEnumerableNullThis.io
@@ -1,3 +1,0 @@
-> Object.prototype.propertyIsEnumerable.call(null, "x")
-< false
--

--- a/tests/unconforming/propertyIsEnumerableUndefinedThis.io
+++ b/tests/unconforming/propertyIsEnumerableUndefinedThis.io
@@ -1,3 +1,0 @@
-> Object.prototype.propertyIsEnumerable.call(undefined, "x")
-< false
--

--- a/tests/unconforming/toLocaleLowerCaseSpecialCasing.io
+++ b/tests/unconforming/toLocaleLowerCaseSpecialCasing.io
@@ -1,3 +1,0 @@
-> print("\u0130".toLocaleLowerCase())
-< i̇
--

--- a/tests/unconforming/toLocaleLowerCaseSupplementaryPlane.io
+++ b/tests/unconforming/toLocaleLowerCaseSupplementaryPlane.io
@@ -1,3 +1,0 @@
-> print("\uD835\uDD0A".toLocaleLowerCase())
-< 𝔊
--

--- a/tests/unconforming/toLocaleUpperCaseSpecialCasing.io
+++ b/tests/unconforming/toLocaleUpperCaseSpecialCasing.io
@@ -1,3 +1,0 @@
-> print("i".toLocaleUpperCase())
-< İ
--

--- a/tests/unconforming/toLocaleUpperCaseSupplementaryPlane.io
+++ b/tests/unconforming/toLocaleUpperCaseSupplementaryPlane.io
@@ -1,3 +1,0 @@
-> print("\uD835\uDD24".toLocaleUpperCase())
-< 𝔊
--

--- a/tests/unconforming/toLowerCaseSupplementaryPlane.io
+++ b/tests/unconforming/toLowerCaseSupplementaryPlane.io
@@ -1,3 +1,0 @@
-> print("\uD835\uDD0A".toLowerCase())
-< 𝔊
--

--- a/tests/unconforming/toUpperCaseSupplementaryPlane.io
+++ b/tests/unconforming/toUpperCaseSupplementaryPlane.io
@@ -1,3 +1,0 @@
-> print("\uD835\uDD0A".toUpperCase())
-< 𝔊
--


### PR DESCRIPTION
## Summary
- drop unconforming regression tests that cover `not_es3` cases for Object.prototype methods on null/undefined
- remove `not_es3` string locale case conversion tests

## Testing
- `timeout 180 ./build.sh`

------
https://chatgpt.com/codex/tasks/task_e_68be992215a8833294d7113fc5e72e15