### PR TITLE
Recognize uppercase 0X in parseInt

### DIFF
--- a/docs/notes/ES3TestFailures.md
+++ b/docs/notes/ES3TestFailures.md
@@ -1,5 +1,5 @@
 # ES3 Test262 Failures Analysis
-50 Test262 tests from the ES3 portion of Test262 still fail in NuXJS. All of these tests target ES3 semantics that NuXJS does not yet implement correctly.
+48 Test262 tests from the ES3 portion of Test262 still fail in NuXJS. All of these tests target ES3 semantics that NuXJS does not yet implement correctly.
 | Feature | Spec Clause | Failures |
 | --- | --- | ---:|
 | Array | §15.4 | 9 |
@@ -8,7 +8,6 @@
 | Function | §15.3 | 1 |
 | RegExp | §15.10 | 17 |
 | String | §15.5 | 11 |
-| parseInt |  | 2 |
 
 The table counts only failing Test262 cases. One additional custom test,
 `unconforming/readOnlyNumericProps`, documents an intentional deviation and is
@@ -1516,9 +1515,9 @@ See `tests/unconforming/parseIntUSP.io` for a regression test.
 		> The **parseInt** function produces an integer value dictated by interpretation of the contents of the *string* argument according to the specified *radix*. Leading whitespace in the string is ignored. If *radix* is **undefined** or 0, it is assumed to be 10 except when the number begins with the character pairs **0x** or **0X**, in which case a radix of 16 is assumed. Any radix-16 number may also optionally begin with the character pairs **0x** or **0X**.
 		>
 		> - 13. If the length of *S* is at least 2 and the first two characters of *S* are either "0x" or "0X", then remove the first two characters from *S* and let *R* = 16.
-NuXJS result: `parseInt("0X1")` returns `0`, ignoring the hexadecimal prefix.
-Expected: strings starting with `0x` or `0X` must parse as base 16 when the radix is undefined or 0, producing `1` for `"0X1"`.
-Plan: Accept an uppercase `0X` prefix when the radix is omitted or 0, mirroring the check for lowercase `0x`.
+Previously, `parseInt("0X1")` returned `0`, ignoring the hexadecimal prefix.
+Now strings starting with `0x` or `0X` parse as base 16 when the radix is undefined or 0, producing `1` for `"0X1"`.
+Resolution: Accept an uppercase `0X` prefix when the radix is omitted or 0, mirroring the check for lowercase `0x`.
 ```io
 > print(parseInt("0X1"))
 < 1
@@ -1528,16 +1527,16 @@ Plan: Accept an uppercase `0X` prefix when the radix is omitted or 0, mirroring 
 -
 ```
 See `tests/unconforming/parseInt0XPrefix.io` for a regression test.
-  - [ ] Fixed
+  - [x] Fixed
 - [x] built-ins/parseInt/S15.1.2.2_A7.2_T3 — Checking algorithm for R = 16
 		> #### **15.1.2.2 parseInt (string , radix)**
 		>
 		> The **parseInt** function produces an integer value dictated by interpretation of the contents of the *string* argument according to the specified *radix*. Leading whitespace in the string is ignored. If *radix* is **undefined** or 0, it is assumed to be 10 except when the number begins with the character pairs **0x** or **0X**, in which case a radix of 16 is assumed. Any radix-16 number may also optionally begin with the character pairs **0x** or **0X**.
 		>
 		> - 13. If the length of *S* is at least 2 and the first two characters of *S* are either "0x" or "0X", then remove the first two characters from *S* and let *R* = 16.
-NuXJS result: `parseInt("0X10", 16)` returns `0` instead of `16`.
-Expected: with radix 16, uppercase `0X` prefixes are valid hexadecimal literals, so `parseInt("0X10", 16)` should be `16`.
-Plan: When radix is 16, strip an optional leading `0X` or `0x` before parsing digits.
+Previously, `parseInt("0X10", 16)` returned `0` instead of `16`.
+With radix 16, uppercase `0X` prefixes are now valid, so `parseInt("0X10", 16)` yields `16`.
+Resolution: When radix is 16, strip an optional leading `0X` or `0x` before parsing digits.
 ```io
 > print(parseInt("0X10", 16))
 < 16
@@ -1547,5 +1546,5 @@ Plan: When radix is 16, strip an optional leading `0X` or `0x` before parsing di
 -
 ```
 See `tests/unconforming/parseIntRadix16Uppercase.io` for a regression test.
-  - [ ] Fixed
+  - [x] Fixed
 

--- a/fails
+++ b/fails
@@ -287,14 +287,3 @@ source
 --- output --- 
  !!!! [object Object]
 
-built-ins/parseInt/S15.1.2.2_A5.2_T2
-source
---- output ---
---- output --- 
- !!!! [object Object]
-
-built-ins/parseInt/S15.1.2.2_A7.2_T3
-source
---- output ---
---- output --- 
- !!!! [object Object]

--- a/src/stdlib.js
+++ b/src/stdlib.js
@@ -1554,10 +1554,11 @@ defineProperties(globals, { dontEnum: true }, {
 			case '-': sign = -1;
 			case '+': ++i;
 		}
-		if (((radix = int32(radix)) === 0 || radix === 16) && (string[i] === '0' && string[i + 1] === 'x')) {
-			i += 2;
-			radix = 16;
-		}
+				if (((radix = int32(radix)) === 0 || radix === 16) && string[i] === '0'
+						&& (string[i + 1] === 'x' || string[i + 1] === 'X')) {
+					i += 2;
+					radix = 16;
+				}
 		if (radix === 0) radix = 10;
 		else if (radix < 2 || radix > 36) return $NaN;
 		var v = 0, b, e = string.length, n;

--- a/src/stdlibJS.cpp
+++ b/src/stdlibJS.cpp
@@ -432,7 +432,7 @@ const char* STDLIB_JS =
 ",isFinite:c(function isFinite(G){return e(+G)}),isNaN:c(function isNaN(G){return d(+G)}),JSON:a.createWrapper(\"JSON\""
 ",void 0),eval:a.evalFunction=c(function eval(bP){return a.eval(bP)}),parseFloat:c(function parseFloat(a7){return a.par"
 "seFloat(P(a7))}),parseInt:c(function parseInt(a7,af){a7=P(a7);var s=r,u=-1,ag=1;while(s[a7[++u]]===null);switch(a7[u])"
-"{case'-':ag=-1;case'+':++u}if(((af=N(af))===0||af===16)&&(a7[u]==='0'&&a7[u+1]==='x')){u+=2;af=16}if(af===0)af=10;else"
+"{case'-':ag=-1;case'+':++u}if(((af=N(af))===0||af===16)&&a7[u]==='0'&&(a7[u+1]==='x'||a7[u+1]==='X')){u+=2;af=16}if(af===0)af=10;else"
 " if(af<2||af>36)return g;var G=0,y,aG=a7.length,C;for(y=u;u<aG&&(C=s[a7[u]])!=null&&C<af;++u)G=G*af+C;return(y===u?g:G"
 "*ag)})});Q(b,{dontEnum:true,dontDelete:true},{NaN:g,Infinity:h,undefined:a.undefined});Q(Math,{readOnly:true,dontEnum:"
 "true,dontDelete:true},{E:2.718281828459045235360,LN10:2.302585092994045684018,LN2:0.6931471805599453094172,LOG10E:0.43"


### PR DESCRIPTION
## Summary
- handle uppercase `0X` prefix for automatic hex parsing in `parseInt`
- regenerate minified standard library
- mark `parseInt` 0X prefix issues as fixed in ES3 test failure notes
- remove `parseInt` from ES3 failure table and drop obsolete entries from fail list

## Testing
- `timeout 180 ./build.sh` *(fails: arrayIndexTooLarge.io, arrayPopLengthInfinity.io, arrayPopPrototypeDelete.io, arrayPushLengthInfinity.io, arrayShiftNegativeLength.io, arrayShiftPrototypeDelete.io, arrayToLocaleStringCallsElements.io, arrayToLocaleStringPrototypeElement.io, booleanIndexCoercion.io, cantAssignObjectToArrayLength.io, datePrototypeSetFullYearInvalidThis.io, dateTimeClipNegativeZero.io, dateYearMonthDateHoursMinutesSecondsUndefined.io, dateYearMonthDateHoursMinutesUndefined.io, dateYearMonthDateHoursUndefined.io, dateYearMonthDateUndefined.io, dateYearMonthUndefined.io, errorConstructorUndefinedMessage.io, errorFunctionUndefinedMessage.io, errorPrototypeNameEnumerable.io, functionPrototypeConstructible.io, hexLiteralOverflow.io, hugeDecimalExponent.io, regExpExecBooleanObject.io, regExpExecNestedCaptures.io, regExpExecNumberObject.io, regExpExecObjectString.io, regExpExecToStringFalse.io, regExpExecToStringObject.io, regExpExecToStringPi.io, regExpExecUndefinedVariable.io, regExpExecValueOfObject.io, regExpWhiteSpace2000.io, stringIndexOfDateThis.io, stringReplace11Concat.io, stringReplace11Plus15.io, stringReplace11PlusA15.io, stringReplaceBackreference.io, stringReplaceThrowingValueOf.io, stringReplaceUndefinedThis.io, toLowerCaseSpecialCasing.io, toLowerCaseSpecialCasingConditional.io, toUpperCaseSpecialCasing.io)*

------
https://chatgpt.com/codex/tasks/task_e_68bef351b9d483328e000ac8f294255e