### PR TITLE
Update evaluation order report with latest Test262 results

### DIFF
--- a/docs/notes/evaluateOrderReport.md
+++ b/docs/notes/evaluateOrderReport.md
@@ -6,23 +6,54 @@ NuXJS documentation, compatibility notes, and standard-library guidelines consis
 •Project guidelines explicitly warn contributors to avoid relying on these non-ES3 evaluation orders.
 
 ### Test262 coverage (externals/test262)
-After running `python2 externals/test262-master/tools/packaging/test262.py --non_strict_only --command "./output/NuXJS -s" --tests externals/test262-master/ <test-path>` on the bundled tests, NuXJS passes most ES3 cases.  Tests targeting assignment order and property key coercion fail, while later language features fail with syntax errors.
+The following tables list every referenced Test262 evaluation-order case. Paths are relative to the Test262 `test/` directory.
 
+#### Targeted assignment and property tests
+| Test file | What it checks | Result |
+| --- | --- | --- |
+| language/expressions/assignment/S11.13.1_A7_T1.js | `base[prop] = expr` with `base` null; left side should run before right side | fail |
+| language/expressions/assignment/S11.13.1_A7_T2.js | `base` undefined variant of the above | fail |
+| language/expressions/assignment/S11.13.1_A7_T3.js | property key coercion throws before evaluating right side | pass |
+| language/expressions/assignment/S11.13.1_A7_T4.js | property key coercion executed only once | pass |
+| language/expressions/postfix-increment/S11.3.1_A6_T1.js | `base[prop]++` with `base` null should evaluate reference once | fail |
 
-**ES3 features – pass**
-•Function call arguments: `S11.2.4_A1.4_T1.js` – `S11.2.4_A1.4_T4.js` confirm left-to-right argument evaluation.
-•Arithmetic operators: `S11.6.1_A2.3_T1.js`, `S11.6.1_A2.4_T1.js` (addition); `S11.6.2_A2.3_T1.js` (subtraction); `S11.5.1_A2.3_T1.js` (multiplication); `S11.5.2_A2.3_T1.js` (division); `S11.5.3_A2.4_T1.js` (modulus).
-•Bitwise & shifts: `S11.7.1_A2.3_T1.js` (<<); `S11.7.2_A2.4_T1.js` (>>); `S11.7.3_A2.3_T1.js` (>>>); `S11.10.2_A2.4_T1.js` (^).
-•Comparisons & membership: `S11.8.1_A2.4_T1.js` (<); `S11.8.2_A2.3_T1.js`, `S11.8.2_A2.4_T1.js` (> with ToNumber + operand order); `test/language/expressions/greater-than/11.8.2-1.js` – `11.8.2-4.js` (>); `test/language/expressions/less-than-or-equal/11.8.3-1.js` – `11.8.3-5.js` (<=); `S11.8.7_A2.4_T1.js` (in); `S11.9.4_A2.4_T1.js` (===); `S11.9.2_A2.4_T1.js` (!=).
-Each file above reported “passed in non-strict mode”.
+#### ES3 evaluation order tests
+| Test file | What it checks | Result |
+| --- | --- | --- |
+| language/expressions/call/S11.2.4_A1.4_T1.js | first argument assignment visible to later arguments | pass |
+| language/expressions/call/S11.2.4_A1.4_T2.js | first argument evaluated before second, triggering ReferenceError | pass |
+| language/expressions/call/S11.2.4_A1.4_T3.js | arguments `x=1,y=x,x+y` evaluated left to right | pass |
+| language/expressions/call/S11.2.4_A1.4_T4.js | first argument throwing prevents evaluation of second | pass |
+| language/expressions/addition/S11.6.1_A2.3_T1.js | ToNumber on left operand runs before right | pass |
+| language/expressions/addition/S11.6.1_A2.4_T1.js | assignments inside `+` are evaluated left to right | pass |
+| language/expressions/subtraction/S11.6.2_A2.3_T1.js | ToNumber on left operand runs before right | pass |
+| language/expressions/multiplication/S11.5.1_A2.3_T1.js | ToNumber on left operand runs before right | pass |
+| language/expressions/division/S11.5.2_A2.3_T1.js | ToNumber on left operand runs before right | pass |
+| language/expressions/modulus/S11.5.3_A2.4_T1.js | assignments inside `%` are evaluated left to right | pass |
+| language/expressions/left-shift/S11.7.1_A2.3_T1.js | ToNumber on left operand runs before right | pass |
+| language/expressions/right-shift/S11.7.2_A2.4_T1.js | assignments inside `>>` are evaluated left to right | pass |
+| language/expressions/unsigned-right-shift/S11.7.3_A2.3_T1.js | ToNumber on left operand runs before right | pass |
+| language/expressions/bitwise-xor/S11.10.2_A2.4_T1.js | assignments inside `^` are evaluated left to right | pass |
+| language/expressions/less-than/S11.8.1_A2.4_T1.js | assignments inside `<` are evaluated left to right | pass |
+| language/expressions/greater-than/S11.8.2_A2.3_T1.js | ToNumber left operand before right in `>` | pass |
+| language/expressions/greater-than/S11.8.2_A2.4_T1.js | assignments inside `>` are evaluated left to right | pass |
+| language/expressions/greater-than/11.8.2-1.js | left `valueOf` runs before right `valueOf` in `>` | pass |
+| language/expressions/greater-than/11.8.2-2.js | left `valueOf` runs before right `toString` in `>` | pass |
+| language/expressions/greater-than/11.8.2-3.js | left `toString` runs before right `valueOf` in `>` | pass |
+| language/expressions/greater-than/11.8.2-4.js | left `toString` runs before right `toString` in `>` | pass |
+| language/expressions/less-than-or-equal/11.8.3-1.js | left `valueOf` runs before right `valueOf` in `<=` | pass |
+| language/expressions/less-than-or-equal/11.8.3-2.js | left `valueOf` runs before right `toString` in `<=` | pass |
+| language/expressions/less-than-or-equal/11.8.3-3.js | left `toString` runs before right `valueOf` in `<=` | pass |
+| language/expressions/less-than-or-equal/11.8.3-4.js | left `toString` runs before right `toString` in `<=` | pass |
+| language/expressions/less-than-or-equal/11.8.3-5.js | mixed coercions still evaluate left side first in `<=` | pass |
+| language/expressions/in/S11.8.7_A2.4_T1.js | assignments inside `in` are evaluated left to right | pass |
+| language/expressions/strict-equals/S11.9.4_A2.4_T1.js | assignments inside `===` are evaluated left to right | pass |
+| language/expressions/does-not-equals/S11.9.2_A2.4_T1.js | assignments inside `!=` are evaluated left to right | pass |
 
-**Not ES3 features – fail or skipped**
-•`test/language/expressions/exponentiation/exp-operator-evaluation-order.js` – exponentiation operator was added after ES3 and triggers a SyntaxError.
-•`test/language/expressions/template-literal/evaluation-order.js` – template literals are an ES2015 feature and trigger a SyntaxError.
+#### Non-ES3 features
+| Test file | What it checks | Result |
+| --- | --- | --- |
+| language/expressions/exponentiation/exp-operator-evaluation-order.js | evaluation order for `**` operator (ES2016) | SyntaxError |
+| language/expressions/template-literal/evaluation-order.js | evaluation order for template literals (ES2015) | SyntaxError |
 
-These tests confirm NuXJS’s left-to-right operand evaluation for ES3 constructs.
-
-**NuXJS deviations – targeted tests**
-•Early conversions: `language/expressions/addition/S11.6.1_A2.3_T1.js` – passes, leaving NuXJS’s earlier coercions unexercised.
-•Assignments: `language/expressions/assignment/S11.13.1_A7_T1.js` – `S11.13.1_A7_T4.js` – fail because NuXJS evaluates the right-hand side before the left-hand side.
-•Property access: `language/expressions/postfix-increment/S11.3.1_A6_T1.js` – fails when `toString` on the property key runs before `ToObject` on the base.
+These tests confirm NuXJS’s left-to-right operand evaluation for ES3 constructs, with assignment targets and property access remaining outliers.


### PR DESCRIPTION
## Summary
- reorganized evaluation-order report to enumerate every referenced Test262 case with descriptions and results

## Testing
- `timeout 180 ./build.sh`
- `python2 externals/test262-master/tools/packaging/test262.py --non_strict_only --command "./output/NuXJS -s" --tests externals/test262-master/ language/expressions/assignment/S11.13.1_A7_T1.js language/expressions/assignment/S11.13.1_A7_T2.js language/expressions/assignment/S11.13.1_A7_T3.js language/expressions/assignment/S11.13.1_A7_T4.js language/expressions/postfix-increment/S11.3.1_A6_T1.js language/expressions/call/S11.2.4_A1.4_T1.js language/expressions/call/S11.2.4_A1.4_T2.js language/expressions/call/S11.2.4_A1.4_T3.js language/expressions/call/S11.2.4_A1.4_T4.js language/expressions/addition/S11.6.1_A2.3_T1.js language/expressions/addition/S11.6.1_A2.4_T1.js language/expressions/subtraction/S11.6.2_A2.3_T1.js language/expressions/multiplication/S11.5.1_A2.3_T1.js language/expressions/division/S11.5.2_A2.3_T1.js language/expressions/modulus/S11.5.3_A2.4_T1.js language/expressions/left-shift/S11.7.1_A2.3_T1.js language/expressions/right-shift/S11.7.2_A2.4_T1.js language/expressions/unsigned-right-shift/S11.7.3_A2.3_T1.js language/expressions/bitwise-xor/S11.10.2_A2.4_T1.js language/expressions/less-than/S11.8.1_A2.4_T1.js language/expressions/greater-than/S11.8.2_A2.3_T1.js language/expressions/greater-than/S11.8.2_A2.4_T1.js language/expressions/greater-than/11.8.2-1.js language/expressions/greater-than/11.8.2-2.js language/expressions/greater-than/11.8.2-3.js language/expressions/greater-than/11.8.2-4.js language/expressions/less-than-or-equal/11.8.3-1.js language/expressions/less-than-or-equal/11.8.3-2.js language/expressions/less-than-or-equal/11.8.3-3.js language/expressions/less-than-or-equal/11.8.3-4.js language/expressions/less-than-or-equal/11.8.3-5.js language/expressions/in/S11.8.7_A2.4_T1.js language/expressions/strict-equals/S11.9.4_A2.4_T1.js language/expressions/does-not-equals/S11.9.2_A2.4_T1.js language/expressions/exponentiation/exp-operator-evaluation-order.js language/expressions/template-literal/evaluation-order.js`

------
https://chatgpt.com/codex/tasks/task_e_68c43337c0a4833290f0d057c9dfba08