### PR TITLE
Validate bracket property references before RHS evaluation

### DIFF
--- a/docs/notes/evaluationOrderTodo.md
+++ b/docs/notes/evaluationOrderTodo.md
@@ -8,7 +8,8 @@ See [evaluationOrderReport](evaluationOrderReport.md) for background and rationa
 ## Findings
 
 - **Non-property assignments still resolve the right-hand side before validating the target.** Named and local assignments only emit the non-throwing `TYPEOF_NAMED_OP`/`READ_LOCAL_OP` probe ahead of right-hand compilation, so an unresolved identifier does not fault until after the right-hand side has already executed—contrary to ES3’s requirement that the reference be resolved first.【F:docs/specs/ECMA-262 3.md†L2879-L2884】【F:docs/specs/ECMA-262 3.md†L1770-L1782】【F:docs/specs/ECMA-262 3.md†L1438-L1446】 Regression coverage in [`tests/unconforming/rightSideBeforeAssignmentRef.io`](../../tests/unconforming/rightSideBeforeAssignmentRef.io) (and its `testsBroken` counterpart) confirms the deviation remains.
-- **Bracket property compilation checks the base too late.** The compiler still emits code that evaluates the property-key expression before validating the base with `CHECK_OBJECT_COERCIBLE_OP`, allowing key side effects to run before `TypeError` is raised. ES3’s `MemberExpression : MemberExpression [ Expression ]` algorithm coerces the base prior to evaluating the property expression, so NuXJS diverges from §11.2.1 here as well.【F:docs/specs/ECMA-262 3.md†L2063-L2071】 Regression tests such as [`tests/erroneous/assignmentNullBaseBracketLeftFirst.io`](../../tests/erroneous/assignmentNullBaseBracketLeftFirst.io), [`assignmentUndefinedBaseBracketLeftFirst.io`](../../tests/erroneous/assignmentUndefinedBaseBracketLeftFirst.io), and [`assignmentPropertyKeyCoercionBeforeBaseCheck.io`](../../tests/erroneous/assignmentPropertyKeyCoercionBeforeBaseCheck.io) show the key expression executing even though the base is `null`/`undefined`.
+- **Bracket property compilation now validates the base before property-key evaluation.** `PROPERTY_BRACKETS` emits `CHECK_OBJECT_COERCIBLE_OP` immediately after compiling the base so `base[prop]` throws prior to any key-side effects, aligning with ES3’s `MemberExpression : MemberExpression [ Expression ]` rules in §11.2.1.【F:docs/specs/ECMA-262 3.md†L2063-L2071】【F:src/NuXJS.cpp†L3670-L3681】 Regression coverage in [`tests/erroneous/assignmentNullBaseBracketLeftFirst.io`](../../tests/erroneous/assignmentNullBaseBracketLeftFirst.io) and [`assignmentUndefinedBaseBracketLeftFirst.io`](../../tests/erroneous/assignmentUndefinedBaseBracketLeftFirst.io) now confirms the key expression is skipped once the base faults.【F:tests/erroneous/assignmentNullBaseBracketLeftFirst.io†L1-L11】【F:tests/erroneous/assignmentUndefinedBaseBracketLeftFirst.io†L1-L11】
+- **Property reference resolution enforces the same ordering for bracket assignments and updates.** `RESOLVE_PROPERTY_OP` now swaps the stack to run `CHECK_OBJECT_COERCIBLE_OP` against the stored base before re-pushing operands, so `base[prop] = rhs` and `base[prop]++` throw prior to any property-key or right-hand evaluation when the base is `null`/`undefined`. Updated regression coverage in [`postfixIncrementNullBaseBracketLeftFirst.io`](../../tests/erroneous/postfixIncrementNullBaseBracketLeftFirst.io) and [`postfixIncrementUndefinedBaseBracketLeftFirst.io`](../../tests/erroneous/postfixIncrementUndefinedBaseBracketLeftFirst.io) confirms the property expression is skipped for both null and undefined bases.【F:tests/erroneous/postfixIncrementNullBaseBracketLeftFirst.io†L1-L10】【F:tests/erroneous/postfixIncrementUndefinedBaseBracketLeftFirst.io†L1-L10】
 - **Conclusion.** NuXJS still deviates from ES3’s mandated evaluation order for unqualified assignments and bracket property accesses; these remain open work even though earlier milestone checkboxes were marked complete.
 
 Each milestone must be completed in order and `timeout 600 ./build.sh` must succeed before advancing to the next.
@@ -19,9 +20,9 @@ Each milestone must be completed in order and `timeout 600 ./build.sh` must succ
 
 ## Milestone 2 – Base object coercion
 - [x] Introduce `CHECK_OBJECT_COERCIBLE_OP` and wire it into the VM.
-- [ ] Reorder bracket compilation so the base is validated and coerced before property-key evaluation, matching ES3 §11.2.1’s requirement that the base be checked prior to the property expression.【F:docs/specs/ECMA-262 3.md†L2063-L2071】
-- [ ] Update regression coverage (e.g. `assignmentNullBaseBracketLeftFirst.io`, `assignmentUndefinedBaseBracketLeftFirst.io`) to verify no key-side effects occur once the base throws.
-- [ ] Run `timeout 180 ./build.sh`.
+- [x] Reorder bracket compilation so the base is validated and coerced before property-key evaluation, matching ES3 §11.2.1’s requirement that the base be checked prior to the property expression.【F:docs/specs/ECMA-262 3.md†L2063-L2071】
+- [x] Update regression coverage (e.g. `assignmentNullBaseBracketLeftFirst.io`, `assignmentUndefinedBaseBracketLeftFirst.io`) to verify no key-side effects occur once the base throws.
+- [x] Run `timeout 180 ./build.sh`.
 
 ## Milestone 3 – Property key conversion
 - [x] Factor `OBJ_TO_STRING_OP` out of property access opcodes.
@@ -34,9 +35,9 @@ Each milestone must be completed in order and `timeout 600 ./build.sh` must succ
 - [x] Run `timeout 600 ./build.sh`.
 
 ## Milestone 5 – Null/undefined base resolution
-- [ ] Integrate `CHECK_OBJECT_COERCIBLE_OP` with property reference resolution for bracket assignments and postfix updates so `base[prop]` throws before any property-key or right-hand evaluation when the base is `null`/`undefined`.
-- [ ] Ensure regression scenarios (`assignmentNullBaseBracketLeftFirst.io`, `assignmentUndefinedBaseBracketLeftFirst.io`, `postfixIncrementNullBaseBracketLeftFirst.io`, etc.) observe the ES3 ordering and pass without key-side effects.
-- [ ] Run `timeout 600 ./build.sh`.
+- [x] Integrate `CHECK_OBJECT_COERCIBLE_OP` with property reference resolution for bracket assignments and postfix updates so `base[prop]` throws before any property-key or right-hand evaluation when the base is `null`/`undefined`.
+- [x] Ensure regression scenarios (`assignmentNullBaseBracketLeftFirst.io`, `assignmentUndefinedBaseBracketLeftFirst.io`, `postfixIncrementNullBaseBracketLeftFirst.io`, etc.) observe the ES3 ordering and pass without key-side effects.
+- [x] Run `timeout 600 ./build.sh`.
 
 ## Milestone 6 – Reference validation for non-property assignments
 - [ ] Ensure variable and unqualified assignments resolve their left-hand references before evaluating the right-hand side, as mandated by ES3 §11.13.1, the scope-chain rules in §10.1.4, and the `PutValue` algorithm in §8.7.2.【F:docs/specs/ECMA-262 3.md†L2879-L2884】【F:docs/specs/ECMA-262 3.md†L1770-L1782】【F:docs/specs/ECMA-262 3.md†L1438-L1446】

--- a/src/NuXJS.cpp
+++ b/src/NuXJS.cpp
@@ -3478,17 +3478,20 @@ bool Compiler::preOperate(ExpressionResult& xr, Precedence precedence) {
 		case PRE_INC_DEC: {
 			assert(op.primitiveInput);
 			assert(op.primitiveOutput);
-					   xr = operand(op);
-					   if (xr.t == ExpressionResult::PROPERTY) {
-							   emit(Processor::RESOLVE_PROPERTY_OP);
-							   emit(Processor::REPUSH_2_OP);
-					   }
-					   makeRValue(xr, true);
-					   emit(op.vmOp);
-					   makeAssignment(xr);
-					   xr = ExpressionResult::PUSHED_PRIMITIVE;
-					   break;
-			   }
+                        xr = operand(op);
+                        if (xr.t == ExpressionResult::PROPERTY) {
+                                emit(Processor::SWAP_OP);
+                                emit(Processor::CHECK_OBJECT_COERCIBLE_OP);
+                                emit(Processor::SWAP_OP);
+                                emit(Processor::RESOLVE_PROPERTY_OP);
+                                emit(Processor::REPUSH_2_OP);
+                        }
+                        makeRValue(xr, true);
+                        emit(op.vmOp);
+                        makeAssignment(xr);
+                        xr = ExpressionResult::PUSHED_PRIMITIVE;
+                        break;
+                }
 		
 		case TYPE_OF: {
 			assert(!op.primitiveInput);
@@ -3566,14 +3569,17 @@ bool Compiler::postOperate(ExpressionResult& xr, Precedence precedence) {
 				p = b;
 				return false;
 			}
-					   if (xr.t == ExpressionResult::PROPERTY) {
-							   emit(Processor::RESOLVE_PROPERTY_OP);
-							   emit(Processor::REPUSH_2_OP);
-					   }
-					   makeRValue(xr, true);
-					   emit(Processor::PLUS_OP);
-					   emit(xr.t == ExpressionResult::PROPERTY ? Processor::POST_SHUFFLE_OP : Processor::REPUSH_OP);
-					   emit(op.vmOp);
+                        if (xr.t == ExpressionResult::PROPERTY) {
+                                emit(Processor::SWAP_OP);
+                                emit(Processor::CHECK_OBJECT_COERCIBLE_OP);
+                                emit(Processor::SWAP_OP);
+                                emit(Processor::RESOLVE_PROPERTY_OP);
+                                emit(Processor::REPUSH_2_OP);
+                        }
+                        makeRValue(xr, true);
+                        emit(Processor::PLUS_OP);
+                        emit(xr.t == ExpressionResult::PROPERTY ? Processor::POST_SHUFFLE_OP : Processor::REPUSH_OP);
+                        emit(op.vmOp);
 			makeAssignment(xr);
 			emit(Processor::POP_OP, 1);
 			xr = ExpressionResult::PUSHED_PRIMITIVE;
@@ -3632,54 +3638,58 @@ bool Compiler::postOperate(ExpressionResult& xr, Precedence precedence) {
 			break;
 		}
 		
-                           case ASSIGNMENT: {
-                                           assert(!op.primitiveInput);
-                                           assert(!op.primitiveOutput);
-                                           if (xr.t == ExpressionResult::PROPERTY) {
-                                                        emit(Processor::RESOLVE_PROPERTY_OP);
-                                           } else if (xr.t == ExpressionResult::NAMED) {
-                                                        emitWithConstant(Processor::TYPEOF_NAMED_OP, xr.v);
-                                                        emit(Processor::POP_OP, 1);
-                                           } else if (xr.t == ExpressionResult::LOCAL) {
-                                                        emit(Processor::READ_LOCAL_OP, xr.v.toInt());
-                                                        emit(Processor::POP_OP, 1);
-                                           }
-                                           const ExpressionResult rxr = makeRValue(operand(op), false);
-                                           makeAssignment(xr);
-                                           xr = rxr;
-                                           break;
-                           }
-			   case COMPOUND_ASSIGNMENT: {
-					   assert(op.primitiveInput);
-					   assert(op.primitiveOutput);
-					   const Processor::Opcode primitiveOp
-									   = (op.vmOp == Processor::ADD_OP ? Processor::OBJ_TO_PRIMITIVE_OP : Processor::OBJ_TO_NUMBER_OP);
-					   if (xr.t == ExpressionResult::PROPERTY) {
-							   emit(Processor::RESOLVE_PROPERTY_OP);
-							   emit(Processor::REPUSH_2_OP);
-					   }
-					   makeRValue(xr, true, primitiveOp);
-					   makeRValue(operand(op), true, primitiveOp);
-					   emit(op.vmOp);
-					   makeAssignment(xr);
-					   xr = ExpressionResult::PUSHED_PRIMITIVE;
-					   break;
-			   }
+                case ASSIGNMENT: {
+                        assert(!op.primitiveInput);
+                        assert(!op.primitiveOutput);
+                        if (xr.t == ExpressionResult::PROPERTY) {
+                                emit(Processor::SWAP_OP);
+                                emit(Processor::CHECK_OBJECT_COERCIBLE_OP);
+                                emit(Processor::SWAP_OP);
+                                emit(Processor::RESOLVE_PROPERTY_OP);
+                        } else if (xr.t == ExpressionResult::NAMED) {
+                                emitWithConstant(Processor::TYPEOF_NAMED_OP, xr.v);
+                                emit(Processor::POP_OP, 1);
+                        } else if (xr.t == ExpressionResult::LOCAL) {
+                                emit(Processor::READ_LOCAL_OP, xr.v.toInt());
+                                emit(Processor::POP_OP, 1);
+                        }
+                        const ExpressionResult rxr = makeRValue(operand(op), false);
+                        makeAssignment(xr);
+                        xr = rxr;
+                        break;
+                }
+                case COMPOUND_ASSIGNMENT: {
+                        assert(op.primitiveInput);
+                        assert(op.primitiveOutput);
+                        const Processor::Opcode primitiveOp
+                                        = (op.vmOp == Processor::ADD_OP ? Processor::OBJ_TO_PRIMITIVE_OP : Processor::OBJ_TO_NUMBER_OP);
+                        if (xr.t == ExpressionResult::PROPERTY) {
+                                emit(Processor::SWAP_OP);
+                                emit(Processor::CHECK_OBJECT_COERCIBLE_OP);
+                                emit(Processor::SWAP_OP);
+                                emit(Processor::RESOLVE_PROPERTY_OP);
+                                emit(Processor::REPUSH_2_OP);
+                        }
+                        makeRValue(xr, true, primitiveOp);
+                        makeRValue(operand(op), true, primitiveOp);
+                        emit(op.vmOp);
+                        makeAssignment(xr);
+                        xr = ExpressionResult::PUSHED_PRIMITIVE;
+                        break;
+                }
 
 		case PROPERTY_BRACKETS: {
 			assert(!op.primitiveInput);
-		makeRValue(xr, false);
-		const bool didAcceptInOperator = acceptInOperator;
+			makeRValue(xr, false);
+			emit(Processor::CHECK_OBJECT_COERCIBLE_OP);
+			const bool didAcceptInOperator = acceptInOperator;
 			acceptInOperator = true;
 			makeRValue(operand(op), false);
-			emit(Processor::SWAP_OP);
-			emit(Processor::CHECK_OBJECT_COERCIBLE_OP);
-			emit(Processor::SWAP_OP);
 			emit(Processor::OBJ_TO_STRING_OP);
 			acceptInOperator = didAcceptInOperator;
 			xr = ExpressionResult(ExpressionResult::PROPERTY);
 			break;
-}
+		}
 		
 		default: assert(0);
 	}

--- a/tests/erroneous/assignmentNullBaseBracketLeftFirst.io
+++ b/tests/erroneous/assignmentNullBaseBracketLeftFirst.io
@@ -5,7 +5,7 @@
 > (null)[hit = 1] = (rhsHit = 1)
 ! !!!! TypeError: Cannot convert undefined or null to object
 > hit
-1
+0
 > rhsHit
 0
 -

--- a/tests/erroneous/assignmentUndefinedBaseBracketLeftFirst.io
+++ b/tests/erroneous/assignmentUndefinedBaseBracketLeftFirst.io
@@ -5,7 +5,7 @@
 > (undefined)[hit = 1] = (rhsHit = 1)
 ! !!!! TypeError: Cannot convert undefined or null to object
 > hit
-1
+0
 > rhsHit
 0
 -

--- a/tests/erroneous/postfixIncrementNullBaseBracketLeftFirst.io
+++ b/tests/erroneous/postfixIncrementNullBaseBracketLeftFirst.io
@@ -3,6 +3,6 @@
 > (null)[hit = 1]++
 ! !!!! TypeError: Cannot convert undefined or null to object
 > hit
-1
+0
 -
 

--- a/tests/erroneous/postfixIncrementUndefinedBaseBracketLeftFirst.io
+++ b/tests/erroneous/postfixIncrementUndefinedBaseBracketLeftFirst.io
@@ -3,6 +3,6 @@
 > (undefined)[hit = 1]++
 ! !!!! TypeError: Cannot convert undefined or null to object
 > hit
-1
+0
 -
 


### PR DESCRIPTION
## Summary
- run `CHECK_OBJECT_COERCIBLE_OP` while resolving bracket property targets so assignments and postfix updates throw before any key or RHS side effects
- update the null/undefined postfix increment regressions to expect the property-key expression to be skipped
- record the completed Milestone 5 work in `evaluationOrderTodo.md`

## Testing
- timeout 600 ./build.sh

------
https://chatgpt.com/codex/tasks/task_e_68c8453d7aa88332b4ae1789121f401a