### PR TITLE
Fix benchmark newline comparison

### DIFF
--- a/tools/benchmark.pika
+++ b/tools/benchmark.pika
@@ -75,11 +75,17 @@ err = try(>{
 		};
 		output = load(outPath);
 		output = replace(output, "\r\n", "\n");
+		for (; length(output) != 0 && right(output, 1) == LF; ) {
+			output = chop(output, 1);
+		};
 		goldenFile = bake('benchmarks{DIR_SLASH}golden{DIR_SLASH}{name}.txt');
 		if (makeGold) {
 			save(goldenFile, output);
 		} else if (ignoregold !== 'ignoregold') {
 			expected = load(goldenFile);
+			for (; length(expected) != 0 && right(expected, 1) == LF; ) {
+				expected = chop(expected, 1);
+			};
 			if (output !== expected) {
 				times = 'FAIL';
 				save("output" # DIR_SLASH # 'failed.txt', output);


### PR DESCRIPTION
## Summary
- trim trailing newline characters from benchmark output and golden data before comparing to avoid spurious failures

## Testing
- `timeout 180 ./build.sh`
- `externals/PikaCmd/PikaCmd tools/benchmark.pika chess_bm`
- `externals/PikaCmd/PikaCmd tools/benchmark.pika math_bm_1`


------
https://chatgpt.com/codex/tasks/task_e_68cdaa5d0ba0833289e49e0ccfa53f4a