### PR TITLE
Fix benchmark runs option defaults

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -7,7 +7,7 @@ This directory contains micro benchmarks used to measure NuXJS performance.
 Use `PikaCmd` to run the script:
 
 ```
-./tools/benchmark.pika <test(s)> <exe>|<rev-range>|makegold ignoregold
+./tools/benchmark.pika <test(s)> <exe>|<rev-range>|makegold ignoregold [--runs <count>]
 ```
 
 - `<test(s)>` is a file name or glob pattern for the benchmarks.
@@ -15,6 +15,8 @@ Use `PikaCmd` to run the script:
 - `<exe>|<rev-range>|makegold` can be the path to the
   already compiled `NuXJS` binary, a single revision number or revision range (e.g. `12345-12350`) checked out and built prior to running, or the literal `makegold` to generate reference output.
 - `ignoregold` is optional and skips output comparison.
+- `--runs <count>` (or `-r <count>`) overrides the number of
+  executions collected before computing the median. The default is 5.
 
 ## Golden results
 

--- a/tools/benchmark.pika
+++ b/tools/benchmark.pika
@@ -4,20 +4,54 @@ include('stdlib.pika');
 include('systools.pika');
 include('debug.pika');
 
-// benchmark.pika <test(s)> <exe>|makegold ignoregold
+// benchmark.pika <test(s)> <exe>|makegold ignoregold [--runs <count>]
 
-vargs(@me,, @tests, @exe, @ignoregold, @runs);
-defaults(@ignoregold, '');
-defaults(@runs, 5);
+tests = void;
+exe = void;
+ignoregold = '';
+runs = 5;
+makeGold = false;
+runsOverride = false;
 
-if (!exists(@tests) || tests === '-') tests = '*.js'
+assignRuns => {
+	args(@value);
+	if (value === void || value === '') throw('Value for --runs must be a positive integer.');
+	value = +value;
+	if (classify(value) !== 'number' || value < 1 || value !== floor(value)) throw('Value for --runs must be a positive integer.');
+	runs = value;
+	runsOverride = true;
+};
+
+for (i = 1; i < $n; ++i) {
+	arg = $[i];
+	if (arg === 'ignoregold') {
+		ignoregold = 'ignoregold';
+	} else if (arg === '--runs' || arg === '-r') {
+		if (++i >= $n) throw('Missing value for --runs.');
+		assignRuns($[i]);
+	} else if (length(arg) > 7 && arg{0:7} === '--runs=') {
+		assignRuns(arg{7:});
+	} else if (length(arg) > 3 && arg{0:3} === '-r=') {
+		assignRuns(arg{3:});
+	} else if (arg === 'makegold' && tests !== void && exe === void) {
+		makeGold = true;
+	} else if (tests === void) {
+		tests = arg;
+	} else if (exe === void) {
+		exe = arg;
+	} else if (!runsOverride && classify(arg) === 'number') {
+		assignRuns(arg);
+	} else {
+		throw('Unknown command line argument: ' # arg);
+	}
+};
+
+if (tests === void || tests === '-') tests = '*.js'
 else if (right(tests, 3) != '.js') tests #= '.js';
 
-makeGold = false;
-if (exists(@exe) && exe === 'makegold') {
-	makeGold = true;
-	delete(@exe);
-};
+if (makeGold) exe = void;
+
+if (exe === void) delete(@exe);
 
 if (PLATFORM === 'UNIX') {
 	defaults(@exe, './output/NuXJS -s -t');


### PR DESCRIPTION
## Summary
- validate --runs inputs after converting to numbers so string arguments work for all flag styles
- delete an unset executable before calling defaults() so the script falls back to the NuXJS binary on every platform

## Testing
- timeout 180 ./build.sh
- externals/PikaCmd/PikaCmd tools/benchmark.pika bigArray --runs 1
- externals/PikaCmd/PikaCmd tools/benchmark.pika bigArray -r=1
- externals/PikaCmd/PikaCmd tools/benchmark.pika bigArray "./output/NuXJS -s -t" ignoregold --runs=1
- externals/PikaCmd/PikaCmd tools/benchmark.pika bigArray makegold ignoregold -r 1
- externals/PikaCmd/PikaCmd tools/benchmark.pika --runs 1 bigArray
- externals/PikaCmd/PikaCmd tools/benchmark.pika bigArray "./output/NuXJS -s -t" 1
- externals/PikaCmd/PikaCmd tools/benchmark.pika bigArray -r 1


------
https://chatgpt.com/codex/tasks/task_e_68d10b32253883328b6c153715292790