### PR TITLE
Add regression test for lone surrogate crash

### DIFF
--- a/tests/regression/loneSurrogateErrorMessageCrash.io
+++ b/tests/regression/loneSurrogateErrorMessageCrash.io
@@ -1,0 +1,6 @@
+// Reproduces the assertion in String::toUTF8String by calling a string
+// containing a lone high surrogate as a function. The runtime tries to
+// stringify the offending value while building the TypeError message,
+// hits the surrogate assumption and aborts.
+> ("\ud9dd")()
+-


### PR DESCRIPTION
## Summary
- add a regression test that exercises calling a string containing a lone surrogate as a function, reproducing the String::toUTF8String assertion

## Testing
- `timeout 180 ./build.sh` *(fails: abort triggered by the new regression case)*

------
https://chatgpt.com/codex/tasks/task_e_68d119419f7483329bf5b42da6371d01