### PR TITLE
Refine JSArray property updates

### DIFF
--- a/src/NuXJS.cpp
+++ b/src/NuXJS.cpp
@@ -1710,6 +1710,31 @@ void JSArray::sliceDenseVector(Runtime& rt, const Value& key) {
 	}
 }
 
+bool JSArray::setOwnPropertyInternal(Runtime& rt, const Value& key, const Value& v, Flags flags, bool& handled) {
+	handled = false;
+	UInt32 index;
+	if (key.toArrayIndex(index)) {
+		if ((flags & (READ_ONLY_FLAG | DONT_ENUM_FLAG | DONT_DELETE_FLAG)) == 0) {
+			assert(flags == STANDARD_FLAGS);
+			handled = true;
+			return setElement(rt, index, v);
+		}
+		sliceDenseVector(rt, key);
+		return false;
+	}
+	if (key.equalsString(LENGTH_STRING)) {
+		const double rawLength = v.toDouble();
+		const UInt32 coercedLength = static_cast<UInt32>(rawLength);
+		if (isNaN(rawLength) || rawLength < 0.0 || rawLength > 4294967295.0
+			|| rawLength != static_cast<double>(coercedLength)) {
+			ScriptException::throwError(rt.getHeap(), RANGE_ERROR, "Invalid array length");
+		}
+		handled = true;
+		return updateLength(coercedLength);
+	}
+	return false;
+}
+
 bool JSArray::setElement(Runtime& rt, UInt32 index, const Value& v) {
 	if (index >= length) {
 		length = index + 1;
@@ -1741,28 +1766,15 @@ bool JSArray::setElement(Runtime& rt, UInt32 index, const Value& v) {
 }
 
 bool JSArray::setOwnProperty(Runtime& rt, const Value& key, const Value& v, Flags flags) {
-	UInt32 index;
-	if (key.toArrayIndex(index)) {
-		if ((flags & (READ_ONLY_FLAG | DONT_ENUM_FLAG | DONT_DELETE_FLAG)) == 0) {
-			assert(flags == STANDARD_FLAGS);
-			return setElement(rt, index, v);
-		}
-		sliceDenseVector(rt, key);
-	} else if (key.equalsString(LENGTH_STRING)) {
-		const double rawLength = v.toDouble();
-		const UInt32 coercedLength = static_cast<UInt32>(rawLength);
-		if (isNaN(rawLength) || rawLength < 0.0 || rawLength > 4294967295.0
-				|| rawLength != static_cast<double>(coercedLength)) {
-			ScriptException::throwError(rt.getHeap(), RANGE_ERROR, "Invalid array length");
-		}
-		return updateLength(coercedLength);
-	}
-	return super::setOwnProperty(rt, key, v, flags);
+	bool handled;
+	const bool result = setOwnPropertyInternal(rt, key, v, flags, handled);
+	return (handled ? result : super::setOwnProperty(rt, key, v, flags));
 }
 
 bool JSArray::updateOwnProperty(Runtime& rt, const Value& key, const Value& v) {
-	UInt32 index;
-	return (key.toArrayIndex(index) ? setOwnProperty(rt, key, v) : super::updateOwnProperty(rt, key, v));
+	bool handled;
+	const bool result = setOwnPropertyInternal(rt, key, v, STANDARD_FLAGS, handled);
+	return (handled ? result : super::updateOwnProperty(rt, key, v));
 }
 
 bool JSArray::deleteOwnProperty(Runtime& rt, const Value& key) {

--- a/src/NuXJS.h
+++ b/src/NuXJS.h
@@ -786,6 +786,7 @@ class JSArray : public LazyJSObject<Object> {
 	protected:
 		virtual void constructCompleteObject(Runtime& rt) const;
 		void sliceDenseVector(Runtime& rt, const Value& key);
+		bool setOwnPropertyInternal(Runtime& rt, const Value& key, const Value& v, Flags flags, bool& handled);
 		UInt32 length;
 		Vector<Value> denseVector;
 		virtual void gcMarkReferences(Heap& heap) const {


### PR DESCRIPTION
## Summary
- centralize JSArray index and length handling in `setOwnPropertyInternal` using a handled flag instead of routing through the superclass directly
- let `setOwnProperty` and `updateOwnProperty` call the superclass only when needed and remove the redundant length helper
- declare the shared helper with the new signature in the header with consistent indentation

## Testing
- timeout 180 ./build.sh

------
https://chatgpt.com/codex/tasks/task_e_68d1a2fc7a0483328343dca45d3879e5