### PR TITLE
Preserve stack trace metadata on rethrow

### DIFF
--- a/src/NuXJS.cpp
+++ b/src/NuXJS.cpp
@@ -3044,8 +3044,10 @@ bool Processor::run(Int32 maxCycles) {
 		try {
 			innerRun();
 		}
-		catch (const ScriptException& x) {
-			throwVirtualException(x.value);
+		catch (ScriptException& x) {
+			if (throwVirtualException(x.value, &x)) {
+				throw;
+			}
 		}
 	}
 	return (ip != 0);


### PR DESCRIPTION
## Summary
- ensure Processor::run preserves metadata on ScriptException rethrows so stack traces retain location and column information

## Testing
- `timeout 180 ./build.sh`


------
https://chatgpt.com/codex/tasks/task_e_68d5159c0ff08332a7f163f107217afe