### PR TITLE
Fix diffguard scripts regression

### DIFF
--- a/tools/diffguard.py
+++ b/tools/diffguard.py
@@ -74,10 +74,16 @@ def guard_diff(base: list[str], alt: list[str], macro: str, path: str) -> list[s
 		sample = base_block[0] if base_block else (alt_block[0] if alt_block else "")
 		indent = _indent(sample)
 		prefix = indent[:-1] if indent else ""
-		out.append(f"{prefix}#if ({macro})\n")
-		out.extend(alt_block)
-		if base_block:
+		if alt_block and base_block:
+			out.append(f"{prefix}#if ({macro})\n")
+			out.extend(alt_block)
 			out.append(f"{prefix}#else\n")
+			out.extend(base_block)
+		elif alt_block:
+			out.append(f"{prefix}#if ({macro})\n")
+			out.extend(alt_block)
+		else:
+			out.append(f"{prefix}#if (!{macro})\n")
 			out.extend(base_block)
 		out.append(f"{prefix}#endif\n")
 	return out
@@ -100,7 +106,13 @@ def remove_empty_guards(lines: list[str], macro: str) -> list[str]:
 					depth += 1
 				elif s.startswith("#endif"):
 					depth -= 1
-				elif depth == 1 and s and not s.startswith("#else") and not s.startswith("#elif") and lines[j].strip():
+				elif (
+					depth == 1
+					and s
+					and not s.startswith("#else")
+					and not s.startswith("#elif")
+					and lines[j].strip()
+				):
 					has_code = True
 				j += 1
 			if not has_code:

--- a/tools/guardAgainstMain.sh
+++ b/tools/guardAgainstMain.sh
@@ -2,23 +2,64 @@
 set -e -o pipefail -u
 cd "$(dirname "$0")"/..
 
-branch=main
-if [[ ${1-} == "--branch" ]]; then
-	branch=$2
-	shift 2
-fi
+usage() {
+	cat <<'EOF'
+Usage: guardAgainstMain.sh [OPTIONS] [DIFFGUARD_ARGS...]
 
+Options:
+	--branch <branch>	Use <branch> as the baseline instead of "main".
+	--macro <macro>		Set the guard macro (default: NUXJS_NOT_MAIN).
+	--remove		Remove existing guards from the destination files.
+	--help			Show this help message and exit.
+EOF
+}
+
+branch=main
+macro=NUXJS_NOT_MAIN
 remove=false
-for arg in "$@"; do
-	if [[ $arg == "--remove" ]]; then
-		remove=true
-		break
-	fi
+declare -a passthrough=()
+
+while [[ $# -gt 0 ]]; do
+	case $1 in
+		--branch)
+			if [[ $# -lt 2 ]]; then
+				echo "Missing argument for --branch" >&2
+				exit 1
+			fi
+			branch=$2
+			shift 2
+			;;
+		--macro)
+			if [[ $# -lt 2 ]]; then
+				echo "Missing argument for --macro" >&2
+				exit 1
+			fi
+			macro=$2
+			shift 2
+			;;
+		--remove)
+			remove=true
+			shift
+			;;
+		--help|-h)
+			usage
+			exit 0
+			;;
+		--)
+			shift
+			passthrough+=("$@")
+			break
+			;;
+		*)
+			passthrough+=("$1")
+			shift
+			;;
+	esac
 done
 
 if $remove; then
-	python3 tools/diffguard.py NUXJS_NOT_MAIN --remove src/NuXJS.cpp src/NuXJS.cpp
-	python3 tools/diffguard.py NUXJS_NOT_MAIN --remove src/NuXJS.h src/NuXJS.h
+	python3 tools/diffguard.py "$macro" --remove src/NuXJS.cpp src/NuXJS.cpp
+	python3 tools/diffguard.py "$macro" --remove src/NuXJS.h src/NuXJS.h
 	exit 0
 fi
 
@@ -29,6 +70,6 @@ trap 'rm -f "$tmp_cpp" "$tmp_h"' EXIT
 git show "$branch:src/NuXJS.cpp" >"$tmp_cpp"
 git show "$branch:src/NuXJS.h" >"$tmp_h"
 
-python3 tools/diffguard.py NUXJS_NOT_MAIN "$@" "$tmp_cpp" src/NuXJS.cpp src/NuXJS.cpp
-python3 tools/diffguard.py NUXJS_NOT_MAIN "$@" "$tmp_h" src/NuXJS.h src/NuXJS.h
+python3 tools/diffguard.py "$macro" "${passthrough[@]}" "$tmp_cpp" src/NuXJS.cpp src/NuXJS.cpp
+python3 tools/diffguard.py "$macro" "${passthrough[@]}" "$tmp_h" src/NuXJS.h src/NuXJS.h
 


### PR DESCRIPTION
## Summary
- declare the passthrough array in guardAgainstMain.sh so it can run with `set -u` and no extra arguments
- adjust diffguard guard generation to emit baseline-only blocks with `#if (!MACRO)` and keep guard removal logic readable

## Testing
- timeout 180 ./build.sh

------
https://chatgpt.com/codex/tasks/task_e_68d7c25a2d90833280a9ad92a2c8360a