### PR TITLE
Stop populating Error stack on construction

### DIFF
--- a/src/NuXJS.cpp
+++ b/src/NuXJS.cpp
@@ -5297,24 +5297,7 @@ struct Support {
 		return UNDEFINED_VALUE;
 	}
 
-#if (NUXJS_VERBOSE_EXCEPTIONS)
-	static Value captureError(Runtime& rt, Processor& processor, UInt32 argc, const Value* argv, Object*) {
-		(void)rt;
-		if (argc >= 1) {
-			Error* errorObject = argv[0].asError();
-			if (errorObject != 0) {
-				Int32 skip = (argc >= 2 ? argv[1].toInt() : 0);
-				if (skip < 0) {
-					skip = 0;
-				}
-				processor.ensureErrorStack(errorObject, static_cast<UInt32>(skip));
-			}
-		}
-		return UNDEFINED_VALUE;
-	}
-#endif
-
-	static Value distinctConstructor(Runtime& rt, Processor&, UInt32 argc, const Value* argv, Object*) {
+static Value distinctConstructor(Runtime& rt, Processor&, UInt32 argc, const Value* argv, Object*) {
 		if (argc >= 1) {
 			Function* regularFunction = argv[0].asFunction();
 			if (regularFunction != 0) {
@@ -5506,11 +5489,7 @@ static struct {
 	FunctorAdapter<NativeFunction> func;
 } SUPPORT_FUNCTIONS[] = {
 	{ "getInternalProperty", Support::getInternalProperty }, { "createWrapper", Support::createWrapper },
-#if (NUXJS_VERBOSE_EXCEPTIONS)
-	{ "captureError", Support::captureError }, { "defineProperty", Support::defineProperty }, { "compileFunction", Support::compileFunction },
-#else
 	{ "defineProperty", Support::defineProperty }, { "compileFunction", Support::compileFunction },
-#endif
 	{ "distinctConstructor", Support::distinctConstructor }, { "callWithArgs", Support::callWithArgs },
 	{ "hasOwnProperty", Support::hasOwnProperty }, { "fromCharCode", Support::fromCharCode },
 	{ "isPropertyEnumerable", Support::isPropertyEnumerable }, { "atan2", Support::atan2 },

--- a/src/stdlib.js
+++ b/src/stdlib.js
@@ -18,7 +18,7 @@
 	@preserve: undefined,upperToLower,value,valueOf,var,void,while,writable,pop,parse,toDateString,instanceof,test
 	@preserve: toPrimitiveNumber,toPrimitiveString,constructor,isPrototypeOf,prototypes,createWrapper,$match
 	@preserve: $sub,createRegExp,CC,global,source,JSON,stringify,toJSON,unshift,compileFunction,localTimeDifference
-	@preserve: splice,split,search,replace,random,evalFunction,updateDateValue,toPrimitive,captureError
+	@preserve: splice,split,search,replace,random,evalFunction,updateDateValue,toPrimitive
 
 	support: {
 		prototypes: {	// built-in prototype objects
@@ -1611,7 +1611,6 @@ function createErrorConstructor(name, prototype) {
 		var e;
 		support.defineProperty(e = support.createWrapper("Error", name, prototype), "message"
 				, (message !== void 0 ? str(message) : ''), false, true, false);
-		support.captureError(e, 1);
 		return e
 	}
 };

--- a/src/stdlibJS.cpp
+++ b/src/stdlibJS.cpp
@@ -447,7 +447,7 @@ const char* STDLIB_JS =
 ")}),round:c(function round(G){return(G===0.0?G:(G>=-0.5&&G<0.0?-0.0:f(G+0.5)))}),sin:c(function sin(G){return a.sin(+G"
 ")}),sqrt:c(function sqrt(G){return a.sqrt(+G)}),tan:c(function tan(G){return a.tan(+G)})});function eh(name,prototype)"
 "{return function(message){var aG;a.defineProperty(aG=a.createWrapper(\"Error\",name,prototype),\"message\",(message!=="
-"void 0?P(message):''),false,true,false);a.captureError(aG,1);return aG}};(function(){var ei=[\"Error\",\"EvalError\","
+"void 0?P(message):''),false,true,false);return aG}};(function(){var ei=[\"Error\",\"EvalError\","
 "\"RangeError\",\"ReferenceError\",\"SyntaxError\",\"TypeError\",\"URIError\"];for(var u=ei.length;--u>=0;){var C,au,X;"
 "a.defineProperty(b,C=ei[u],au=eh(C,X=a.prototypes[C]),false,true,false);au.name=C;Q(au,{dontEnum:true,readOnly:true,do"
 "ntDelete:true},{prototype:X});Q(X,{dontEnum:true},{constructor:au});X.name=C}Q(Error.prototype,{dontEnum:true},{messag"

--- a/tests/regression/errorStackProperty.io
+++ b/tests/regression/errorStackProperty.io
@@ -1,7 +1,4 @@
-> var direct = new Error("direct check"); var directLines = direct.stack.split("\n"); print(typeof direct.stack === "string"); print(direct.stack.indexOf("direct check") >= 0); print(typeof direct.error === "undefined"); print(directLines[0] === "Error: direct check"); print(directLines[1].indexOf("    at ") === 0);
-< true
-< true
-< true
+> var direct = new Error("direct check"); print(typeof direct.stack === "undefined"); print('stack' in direct === false);
 < true
 < true
 -


### PR DESCRIPTION
## Summary
- remove the support.captureError helper and drop registration from the native support table
- stop calling captureError from createErrorConstructor so new Error() no longer collects a stack trace
- adjust the regression test to expect no stack on freshly constructed errors

## Testing
- timeout 180 ./build.sh

------
https://chatgpt.com/codex/tasks/task_e_68dea1f7bdec83328fedeec3d85889fa